### PR TITLE
Implement basic cheat manager

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,15 @@ We also have a [**Discord**](https://discord.gg/xF85vbZ) server to discuss the d
         alt="Discord" />
 </a>
 
+### Cheats
+
+Cheat support can be enabled by setting `cheats = on` in `fheroes2.cfg`.
+When active, type the following words during gameplay:
+
+* **showmap** – reveal the entire world map.
+* **resources** – gain a large amount of all resources.
+* **blackdragon** – add a stack of Black Dragons to the focused hero.
+
 ## Frequently Asked Questions (FAQ)
 
 You can find answers to the most commonly asked questions on our [**F.A.Q. page**](https://github.com/ihhub/fheroes2/wiki/F.A.Q.).

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -38,6 +38,7 @@
 #include "campaign_savedata.h"
 #include "castle.h"
 #include "cursor.h"
+#include "game_cheats.h"
 #include "difficulty.h"
 #include "game_credits.h"
 #include "game_hotkeys.h"
@@ -195,6 +196,8 @@ void Game::Init()
     LocalEvent & eventHandler = LocalEvent::Get();
     eventHandler.setGlobalMouseMotionEventHook( Cursor::updateCursorPosition );
     eventHandler.setGlobalKeyDownEventHook( globalKeyDownEvent );
+
+    GameCheats::enableCheats( Settings::Get().areCheatsEnabled() );
 
     AnimateDelaysInitialize();
 

--- a/src/fheroes2/game/game_cheats.cpp
+++ b/src/fheroes2/game/game_cheats.cpp
@@ -1,0 +1,86 @@
+#include "game_cheats.h"
+
+#include <SDL2/SDL.h>
+#include "logging.h"
+#include "settings.h"
+#include "world.h"
+#include "kingdom.h"
+#include "resource.h"
+#include "game_interface.h"
+#include "heroes.h"
+#include "monster.h"
+
+namespace GameCheats
+{
+    namespace
+    {
+        std::string buffer;
+        bool enabled = false;
+
+        const size_t MAX_BUFFER = 32;
+
+        void checkBuffer()
+        {
+            if ( buffer.find( "showmap" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: showmap" );
+                World::Get().ClearFog( Settings::Get().CurrentColor() );
+                buffer.clear();
+            }
+            else if ( buffer.find( "resources" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: resources" );
+                Kingdom & kingdom = World::Get().GetKingdom( Settings::Get().CurrentColor() );
+                kingdom.AddFundsResource( Funds( 0, 0, 0, 0, 0, 0, 10000 ) );
+                kingdom.AddFundsResource( Funds( Resource::WOOD, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::ORE, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::MERCURY, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::SULFUR, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::CRYSTAL, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::GEMS, 999 ) );
+                buffer.clear();
+            }
+            else if ( buffer.find( "blackdragon" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: blackdragon" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    hero->GetArmy().JoinTroop( Monster::BLACK_DRAGON, 5, false );
+                }
+                buffer.clear();
+            }
+        }
+    }
+
+    void enableCheats( bool enable )
+    {
+        enabled = enable;
+        if ( !enable )
+            buffer.clear();
+    }
+
+    bool cheatsEnabled()
+    {
+        return enabled;
+    }
+
+    void reset()
+    {
+        buffer.clear();
+    }
+
+    void onKeyPressed( const fheroes2::Key key, const int32_t modifier )
+    {
+        if ( !enabled || SDL_IsTextInputActive() )
+            return;
+
+        std::string tmp;
+        size_t pos = 0;
+        pos = fheroes2::InsertKeySym( tmp, pos, key, modifier );
+        if ( pos == 0 || tmp.empty() )
+            return;
+
+        buffer += tmp;
+        if ( buffer.size() > MAX_BUFFER )
+            buffer.erase( 0, buffer.size() - MAX_BUFFER );
+
+        checkBuffer();
+    }
+}
+

--- a/src/fheroes2/game/game_cheats.h
+++ b/src/fheroes2/game/game_cheats.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include "localevent.h"
+
+namespace GameCheats
+{
+    void enableCheats( bool enable );
+    bool cheatsEnabled();
+
+    // Append a key press to internal buffer and perform cheat detection.
+    void onKeyPressed( const fheroes2::Key key, const int32_t modifier );
+
+    // Reset internal typed buffer.
+    void reset();
+}
+

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include "game_hotkeys.h"
+#include "game_cheats.h"
 
 #include <algorithm>
 #include <array>
@@ -490,6 +491,10 @@ void Game::globalKeyDownEvent( const fheroes2::Key key, const int32_t modifier )
 {
     if ( ( modifier & fheroes2::KeyModifier::KEY_MODIFIER_ALT ) || ( modifier & fheroes2::KeyModifier::KEY_MODIFIER_CTRL ) ) {
         return;
+    }
+
+    if ( Settings::Get().areCheatsEnabled() ) {
+        GameCheats::onKeyPressed( key, modifier );
     }
 
     Settings & conf = Settings::Get();

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -80,7 +80,8 @@ namespace
         GAME_BATTLE_AUTO_RESOLVE = 0x04000000,
         GAME_BATTLE_AUTO_SPELLCAST = 0x08000000,
         GAME_AUTO_SAVE_AT_BEGINNING_OF_TURN = 0x10000000,
-        GAME_SCREEN_SCALING_TYPE_NEAREST = 0x20000000
+        GAME_SCREEN_SCALING_TYPE_NEAREST = 0x20000000,
+        GAME_CHEATS = 0x40000000
     };
 
     enum EditorOptions : uint32_t
@@ -328,6 +329,10 @@ bool Settings::Read( const std::string & filePath )
         setSystemInfo( config.StrParams( "system info" ) == "on" );
     }
 
+    if ( config.Exists( "cheats" ) ) {
+        setCheatsEnabled( config.StrParams( "cheats" ) == "on" );
+    }
+
     if ( config.Exists( "auto save at the beginning of the turn" ) ) {
         setAutoSaveAtBeginningOfTurn( config.StrParams( "auto save at the beginning of the turn" ) == "on" );
     }
@@ -503,6 +508,9 @@ std::string Settings::String() const
 
     os << std::endl << "# display system information: on/off" << std::endl;
     os << "system info = " << ( _gameOptions.Modes( GAME_SYSTEM_INFO ) ? "on" : "off" ) << std::endl;
+
+    os << std::endl << "# enable cheat codes input: on/off" << std::endl;
+    os << "cheats = " << ( _gameOptions.Modes( GAME_CHEATS ) ? "on" : "off" ) << std::endl;
 
     os << std::endl << "# should auto save be performed at the beginning of the turn instead of the end of the turn: on/off" << std::endl;
     os << "auto save at the beginning of the turn = " << ( _gameOptions.Modes( GAME_AUTO_SAVE_AT_BEGINNING_OF_TURN ) ? "on" : "off" ) << std::endl;
@@ -779,6 +787,16 @@ void Settings::setTextSupportMode( const bool enable )
     }
 }
 
+void Settings::setCheatsEnabled( const bool enable )
+{
+    if ( enable ) {
+        _gameOptions.SetModes( GAME_CHEATS );
+    }
+    else {
+        _gameOptions.ResetModes( GAME_CHEATS );
+    }
+}
+
 void Settings::set3DAudio( const bool enable )
 {
     if ( enable ) {
@@ -873,6 +891,11 @@ bool Settings::isMonochromeCursorEnabled() const
 bool Settings::isTextSupportModeEnabled() const
 {
     return _gameOptions.Modes( GAME_TEXT_SUPPORT_MODE );
+}
+
+bool Settings::areCheatsEnabled() const
+{
+    return _gameOptions.Modes( GAME_CHEATS );
 }
 
 bool Settings::is3DAudioEnabled() const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -191,6 +191,7 @@ public:
     bool isPriceOfLoyaltySupported() const;
     bool isMonochromeCursorEnabled() const;
     bool isTextSupportModeEnabled() const;
+    bool areCheatsEnabled() const;
     bool is3DAudioEnabled() const;
     bool isSystemInfoEnabled() const;
     bool isAutoSaveAtBeginningOfTurnEnabled() const;
@@ -263,6 +264,7 @@ public:
     void setFullScreen( const bool enable );
     void setMonochromeCursor( const bool enable );
     void setTextSupportMode( const bool enable );
+    void setCheatsEnabled( const bool enable );
     void set3DAudio( const bool enable );
     void setVSync( const bool enable );
     void setSystemInfo( const bool enable );


### PR DESCRIPTION
## Summary
- implement a simple keyboard cheat manager
- hook cheat handler into global key events and game initialization
- add configuration flag to enable cheats
- document available cheat commands
- add a cheat to spawn black dragons

## Testing
- `make -j$(nproc --ignore=1)`