### PR TITLE
Enable 6 unit slots

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1935,7 +1935,7 @@ void Army::ArrangeForBattle( const Monster & monster, const uint32_t monstersCou
     ArrangeForBattle( monster, monstersCount, stacksCount );
 
     if ( allowUpgrade ) {
-        assert( size() % 2 == 1 );
+        assert( size() > 0 );
 
         // An upgraded stack can be located only in the center
         Troop * troopToUpgrade = at( size() / 2 );

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -159,7 +159,7 @@ struct NeutralMonsterJoiningCondition
 class Army final : public Troops, public Control
 {
 public:
-    static const size_t maximumTroopCount = 5;
+    static const size_t maximumTroopCount = 6;
 
     static std::string SizeString( uint32_t );
     static std::string TroopSizeString( const Troop & );

--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -166,7 +166,7 @@ bool Battle::Only::setup( const bool allowBackup, bool & reset )
         }
         else {
             info.ui.army = std::make_unique<ArmyBar>( &info.monster, true, false, true );
-            info.ui.army->setTableSize( { 5, 1 } );
+            info.ui.army->setTableSize( { 6, 1 } );
             info.ui.army->setRenderingOffset( { cur_pt.x + armyOffsetX[info.armyId], cur_pt.y + 267 } );
             info.ui.army->setInBetweenItemsOffset( { 2, 0 } );
         }
@@ -564,7 +564,7 @@ void Battle::Only::updateArmyUI( ArmyUI & ui, Heroes * hero, const fheroes2::Poi
     ui.artifact->setRenderingOffset( { offset.x + artifactOffsetX[armyId], offset.y + 347 } );
 
     ui.army = std::make_unique<ArmyBar>( &hero->GetArmy(), true, false, true );
-    ui.army->setTableSize( { 5, 1 } );
+    ui.army->setTableSize( { 6, 1 } );
     ui.army->setRenderingOffset( { offset.x + armyOffsetX[armyId], offset.y + 267 } );
     ui.army->setInBetweenItemsOffset( { 2, 0 } );
 }

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -175,6 +175,9 @@ void Castle::LoadFromMP2( const std::vector<uint8_t> & data )
     // - uint8_t (1 byte)
     //    Custom defender monster type in army slot 5.
     //
+    // - uint8_t (1 byte)
+    //    Custom defender monster type in army slot 6.
+    //
     // - uint16_t (2 bytes)
     //    The number of custom defender monsters in army slot 1.
     //
@@ -189,6 +192,9 @@ void Castle::LoadFromMP2( const std::vector<uint8_t> & data )
     //
     // - uint16_t (2 bytes)
     //    The number of custom defender monsters in army slot 5.
+    //
+    // - uint16_t (2 bytes)
+    //    The number of custom defender monsters in army slot 6.
     //
     // - uint8_t (1 byte)
     //     Does the town / castle have captain?

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -209,7 +209,7 @@ namespace
         fheroes2::Copy( port, 0, 0, image, 5, 5, port.width(), port.height() );
 
         ArmyBar armyBar( &hero->GetArmy(), false, false );
-        armyBar.setTableSize( { 5, 1 } );
+        armyBar.setTableSize( { 6, 1 } );
         armyBar.setRenderingOffset( { 112, 5 } );
         armyBar.setInBetweenItemsOffset( { 6, 0 } );
         armyBar.Redraw( image );
@@ -333,7 +333,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
     RedrawIcons( *this, ( alphaHero == 0 ) ? nullptr : hero, dialogRoi.getPosition() );
 
     auto setArmyBarParameters = []( ArmyBar & armyBar, const fheroes2::Point & offset ) {
-        armyBar.setTableSize( { 5, 1 } );
+        armyBar.setTableSize( { 6, 1 } );
         armyBar.setRenderingOffset( offset );
         armyBar.setInBetweenItemsOffset( { 6, 0 } );
     };

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -348,6 +348,9 @@ void Heroes::LoadFromMP2( const int32_t mapIndex, const int colorType, const int
     // - uint8_t (1 byte)
     //    Custom monster type in army slot 5.
     //
+    // - uint8_t (1 byte)
+    //    Custom monster type in army slot 6.
+    //
     // - uint16_t (2 bytes)
     //    The number of custom monsters in army slot 1.
     //
@@ -362,6 +365,9 @@ void Heroes::LoadFromMP2( const int32_t mapIndex, const int colorType, const int
     //
     // - uint16_t (2 bytes)
     //    The number of custom monsters in army slot 5.
+    //
+    // - uint16_t (2 bytes)
+    //    The number of custom monsters in army slot 6.
     //
     // - uint8_t (1 byte)
     //     Does the hero have a custom portrait?

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -296,7 +296,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
 
     // In Editor mode we allow to edit army and remove all customized troops from the army.
     ArmyBar selectArmy( &army, false, readonly, isEditor, !isEditor );
-    selectArmy.setTableSize( { 5, 1 } );
+    selectArmy.setTableSize( { 6, 1 } );
     selectArmy.setRenderingOffset( dst_pt );
     selectArmy.setInBetweenItemsOffset( { 6, 0 } );
     selectArmy.Redraw( display );

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -417,7 +417,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
     dst_pt.y = cur_pt.y + 267;
 
     MeetingArmyBar selectArmy1( &GetArmy() );
-    selectArmy1.setTableSize( { 5, 1 } );
+    selectArmy1.setTableSize( { 6, 1 } );
     selectArmy1.setRenderingOffset( dst_pt );
     selectArmy1.setInBetweenItemsOffset( { 2, 0 } );
     selectArmy1.Redraw( display );
@@ -426,7 +426,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
     dst_pt.y = cur_pt.y + 267;
 
     MeetingArmyBar selectArmy2( &otherHero.GetArmy() );
-    selectArmy2.setTableSize( { 5, 1 } );
+    selectArmy2.setTableSize( { 6, 1 } );
     selectArmy2.setRenderingOffset( dst_pt );
     selectArmy2.setInBetweenItemsOffset( { 2, 0 } );
     selectArmy2.Redraw( display );

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -144,7 +144,7 @@ namespace
 
             armyBar = std::make_unique<ArmyBar>( &hero->GetArmy(), true, false );
             armyBar->SetBackground( { 41, 53 }, fheroes2::GetColorId( 72, 28, 0 ) );
-            armyBar->setTableSize( { 5, 1 } );
+            armyBar->setTableSize( { 6, 1 } );
             armyBar->setInBetweenItemsOffset( { -1, 0 } );
             armyBar->setTroopWindowOffsetY( -60 );
 
@@ -417,7 +417,7 @@ namespace
 
             garrisonArmyBar = std::make_unique<ArmyBar>( &castle->GetArmy(), true, false );
             garrisonArmyBar->SetBackground( { 41, 41 }, fheroes2::GetColorId( 40, 12, 0 ) );
-            garrisonArmyBar->setTableSize( { 5, 1 } );
+            garrisonArmyBar->setTableSize( { 6, 1 } );
             garrisonArmyBar->setInBetweenItemsOffset( { -1, 0 } );
             garrisonArmyBar->setTroopWindowOffsetY( -60 );
 
@@ -435,7 +435,7 @@ namespace
             if ( hero ) {
                 heroArmyBar = std::make_unique<ArmyBar>( &hero->GetArmy(), true, false );
                 heroArmyBar->SetBackground( { 41, 41 }, fheroes2::GetColorId( 40, 12, 0 ) );
-                heroArmyBar->setTableSize( { 5, 1 } );
+                heroArmyBar->setTableSize( { 6, 1 } );
                 heroArmyBar->setInBetweenItemsOffset( { -1, 0 } );
             }
             else {

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -72,7 +72,7 @@ namespace
         const Maps::Map_Format::TileObjectInfo * info{ nullptr };
     };
 
-    void loadArmyFromMetadata( Army & army, const std::array<int32_t, 5> & unitType, const std::array<int32_t, 5> & unitCount )
+    void loadArmyFromMetadata( Army & army, const std::array<int32_t, 6> & unitType, const std::array<int32_t, 6> & unitCount )
     {
         std::vector<Troop> troops( unitType.size() );
         for ( size_t i = 0; i < troops.size(); ++i ) {
@@ -83,7 +83,7 @@ namespace
         army.Assign( troops.data(), troops.data() + troops.size() );
     }
 
-    void saveArmyToMetadata( const Army & army, std::array<int32_t, 5> & unitType, std::array<int32_t, 5> & unitCount )
+    void saveArmyToMetadata( const Army & army, std::array<int32_t, 6> & unitType, std::array<int32_t, 6> & unitCount )
     {
         const size_t armySize = army.Size();
         assert( unitType.size() == armySize );

--- a/src/fheroes2/maps/map_format_info.h
+++ b/src/fheroes2/maps/map_format_info.h
@@ -65,8 +65,8 @@ namespace Maps::Map_Format
         std::string customName;
 
         // Defending monsters that are set in the castle. Type ( < 0 ) means default units (for neutral race) and 0 means an empty army slot.
-        std::array<int32_t, 5> defenderMonsterType{ 0 };
-        std::array<int32_t, 5> defenderMonsterCount{ 0 };
+        std::array<int32_t, 6> defenderMonsterType{ 0 };
+        std::array<int32_t, 6> defenderMonsterCount{ 0 };
 
         // Whether the buildings are customized.
         bool customBuildings{ false };
@@ -113,8 +113,8 @@ namespace Maps::Map_Format
         int32_t customPortrait{ 0 };
 
         // Custom hero army. Type 0 means not set.
-        std::array<int32_t, 5> armyMonsterType{ 0 };
-        std::array<int32_t, 5> armyMonsterCount{ 0 };
+        std::array<int32_t, 6> armyMonsterType{ 0 };
+        std::array<int32_t, 6> armyMonsterCount{ 0 };
 
         // Artifacts with metadata. Type 0 means not set.
         std::array<int32_t, 14> artifact{ 0 };


### PR DESCRIPTION
## Summary
- bump max troop count from 5 to 6
- adjust map metadata arrays to hold 6 slots
- update army metadata helpers
- resize all army bars to show 6 slots
- clarify metadata comments for heroes and castles

## Testing
- `cmake -B build`
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build` *(no tests found)*