### PR TITLE
Implement numeric cheat codes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,20 @@ We also have a [**Discord**](https://discord.gg/xF85vbZ) server to discuss the d
         alt="Discord" />
 </a>
 
+### Cheats
+
+Cheat support can be enabled by setting `cheats = on` in `fheroes2.cfg`.
+When active, type the following numeric codes during gameplay:
+
+* **11111** – reveal the entire world map.
+* **22222** – gain a large amount of all resources.
+* **32167** – add five Black Dragons to the focused hero.
+* **33333** – max out the focused hero's skills.
+* **44444** – replenish the focused hero's movement points.
+* **55555** – instantly win the current map.
+* **66666** – learn all spells and restore spell points for the focused hero.
+* **77777** – build every building in the focused castle.
+
 ## Frequently Asked Questions (FAQ)
 
 You can find answers to the most commonly asked questions on our [**F.A.Q. page**](https://github.com/ihhub/fheroes2/wiki/F.A.Q.).

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -38,6 +38,7 @@
 #include "campaign_savedata.h"
 #include "castle.h"
 #include "cursor.h"
+#include "game_cheats.h"
 #include "difficulty.h"
 #include "game_credits.h"
 #include "game_hotkeys.h"
@@ -195,6 +196,8 @@ void Game::Init()
     LocalEvent & eventHandler = LocalEvent::Get();
     eventHandler.setGlobalMouseMotionEventHook( Cursor::updateCursorPosition );
     eventHandler.setGlobalKeyDownEventHook( globalKeyDownEvent );
+
+    GameCheats::enableCheats( Settings::Get().areCheatsEnabled() );
 
     AnimateDelaysInitialize();
 

--- a/src/fheroes2/game/game_cheats.cpp
+++ b/src/fheroes2/game/game_cheats.cpp
@@ -1,0 +1,147 @@
+#include "game_cheats.h"
+
+#include <SDL2/SDL.h>
+#include "logging.h"
+#include "settings.h"
+#include "world.h"
+#include "kingdom.h"
+#include "resource.h"
+#include "game_interface.h"
+#include "castle.h"
+#include "heroes.h"
+#include "monster.h"
+#include "spell.h"
+#include "game_over.h"
+
+namespace GameCheats
+{
+    namespace
+    {
+        std::string buffer;
+        bool enabled = false;
+
+        const size_t MAX_BUFFER = 32;
+
+        const char * const CODE_SHOWMAP = "11111";
+        const char * const CODE_RESOURCES = "22222";
+        const char * const CODE_BLACKDRAGONS = "32167";
+        const char * const CODE_MAXSKILLS = "33333";
+        const char * const CODE_INFINITEWALK = "44444";
+        const char * const CODE_INSTANTWIN = "55555";
+        const char * const CODE_MAXSPELLS = "66666";
+        const char * const CODE_BUILDALL = "77777";
+
+        void checkBuffer()
+        {
+            if ( buffer.find( CODE_SHOWMAP ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: show map" );
+                World::Get().ClearFog( Settings::Get().CurrentColor() );
+                buffer.clear();
+            }
+            else if ( buffer.find( CODE_RESOURCES ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: resources" );
+                Kingdom & kingdom = World::Get().GetKingdom( Settings::Get().CurrentColor() );
+                kingdom.AddFundsResource( Funds( 0, 0, 0, 0, 0, 0, 10000 ) );
+                kingdom.AddFundsResource( Funds( Resource::WOOD, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::ORE, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::MERCURY, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::SULFUR, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::CRYSTAL, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::GEMS, 999 ) );
+                buffer.clear();
+            }
+            else if ( buffer.find( CODE_BLACKDRAGONS ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: black dragons" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    hero->GetArmy().JoinTroop( Monster::BLACK_DRAGON, 5, true );
+                }
+                buffer.clear();
+            }
+            else if ( buffer.find( CODE_MAXSKILLS ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: max skills" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    hero->setAttackBaseValue( 12 );
+                    hero->setDefenseBaseValue( 12 );
+                    hero->setPowerBaseValue( 12 );
+                    hero->setKnowledgeBaseValue( 12 );
+
+                    for ( Skill::Secondary & skill : hero->GetSecondarySkills().ToVector() ) {
+                        if ( skill.isValid() )
+                            skill.SetLevel( Skill::Level::EXPERT );
+                    }
+                }
+                buffer.clear();
+            }
+            else if ( buffer.find( CODE_INFINITEWALK ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: infinite walk" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    hero->SetMovePoints( hero->GetMaxMovePoints() * 10 );
+                }
+                buffer.clear();
+            }
+            else if ( buffer.find( CODE_INSTANTWIN ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: instant win" );
+                GameOver::Result::Get().SetResult( GameOver::WINS_ALL );
+                GameOver::Result::Get().checkGameOver();
+                buffer.clear();
+            }
+            else if ( buffer.find( CODE_MAXSPELLS ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: max spells" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    hero->SpellBookActivate();
+                    for ( const int spellId : Spell::getAllSpellIdsSuitableForSpellBook() ) {
+                        hero->AppendSpellToBook( Spell( spellId ), true );
+                    }
+                    hero->SetSpellPoints( hero->GetMaxSpellPoints() );
+                }
+                buffer.clear();
+            }
+            else if ( buffer.find( CODE_BUILDALL ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: build all" );
+                if ( Castle * castle = Interface::GetFocusCastle() ) {
+                    for ( uint32_t bit = 1; bit; bit <<= 1 ) {
+                        if ( castle->AllowBuyBuilding( bit ) )
+                            castle->BuyBuilding( bit );
+                    }
+                }
+                buffer.clear();
+            }
+        }
+    }
+
+    void enableCheats( bool enable )
+    {
+        enabled = enable;
+        if ( !enable )
+            buffer.clear();
+    }
+
+    bool cheatsEnabled()
+    {
+        return enabled;
+    }
+
+    void reset()
+    {
+        buffer.clear();
+    }
+
+    void onKeyPressed( const fheroes2::Key key, const int32_t modifier )
+    {
+        if ( !enabled || SDL_IsTextInputActive() )
+            return;
+
+        std::string tmp;
+        size_t pos = 0;
+        pos = fheroes2::InsertKeySym( tmp, pos, key, modifier );
+        if ( pos == 0 || tmp.empty() )
+            return;
+
+        buffer += tmp;
+        if ( buffer.size() > MAX_BUFFER )
+            buffer.erase( 0, buffer.size() - MAX_BUFFER );
+
+        checkBuffer();
+    }
+}
+

--- a/src/fheroes2/game/game_cheats.h
+++ b/src/fheroes2/game/game_cheats.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include "localevent.h"
+
+namespace GameCheats
+{
+    void enableCheats( bool enable );
+    bool cheatsEnabled();
+
+    // Append a key press to internal buffer and perform cheat detection.
+    void onKeyPressed( const fheroes2::Key key, const int32_t modifier );
+
+    // Reset internal typed buffer.
+    void reset();
+}
+

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include "game_hotkeys.h"
+#include "game_cheats.h"
 
 #include <algorithm>
 #include <array>
@@ -490,6 +491,10 @@ void Game::globalKeyDownEvent( const fheroes2::Key key, const int32_t modifier )
 {
     if ( ( modifier & fheroes2::KeyModifier::KEY_MODIFIER_ALT ) || ( modifier & fheroes2::KeyModifier::KEY_MODIFIER_CTRL ) ) {
         return;
+    }
+
+    if ( Settings::Get().areCheatsEnabled() ) {
+        GameCheats::onKeyPressed( key, modifier );
     }
 
     Settings & conf = Settings::Get();

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -410,6 +410,11 @@ GameOver::Result::Result()
     , result( 0 )
 {}
 
+void GameOver::Result::SetResult( uint32_t res )
+{
+    result = res;
+}
+
 void GameOver::Result::Reset()
 {
     colors = Game::GetKingdomColors();

--- a/src/fheroes2/game/game_over.h
+++ b/src/fheroes2/game/game_over.h
@@ -80,6 +80,8 @@ namespace GameOver
             return result;
         }
 
+        void SetResult( uint32_t res );
+
         fheroes2::GameMode checkGameOver();
 
     private:

--- a/src/fheroes2/heroes/heroes_base.h
+++ b/src/fheroes2/heroes/heroes_base.h
@@ -128,6 +128,11 @@ public:
         magic_point = points;
     }
 
+    void SetMovePoints( const uint32_t points )
+    {
+        move_point = points;
+    }
+
     bool isPotentSpellcaster() const;
 
     // Returns all spells that the hero can cast (including spells from the spell book and spell scrolls)

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -80,7 +80,8 @@ namespace
         GAME_BATTLE_AUTO_RESOLVE = 0x04000000,
         GAME_BATTLE_AUTO_SPELLCAST = 0x08000000,
         GAME_AUTO_SAVE_AT_BEGINNING_OF_TURN = 0x10000000,
-        GAME_SCREEN_SCALING_TYPE_NEAREST = 0x20000000
+        GAME_SCREEN_SCALING_TYPE_NEAREST = 0x20000000,
+        GAME_CHEATS = 0x40000000
     };
 
     enum EditorOptions : uint32_t
@@ -328,6 +329,10 @@ bool Settings::Read( const std::string & filePath )
         setSystemInfo( config.StrParams( "system info" ) == "on" );
     }
 
+    if ( config.Exists( "cheats" ) ) {
+        setCheatsEnabled( config.StrParams( "cheats" ) == "on" );
+    }
+
     if ( config.Exists( "auto save at the beginning of the turn" ) ) {
         setAutoSaveAtBeginningOfTurn( config.StrParams( "auto save at the beginning of the turn" ) == "on" );
     }
@@ -503,6 +508,9 @@ std::string Settings::String() const
 
     os << std::endl << "# display system information: on/off" << std::endl;
     os << "system info = " << ( _gameOptions.Modes( GAME_SYSTEM_INFO ) ? "on" : "off" ) << std::endl;
+
+    os << std::endl << "# enable cheat codes input: on/off" << std::endl;
+    os << "cheats = " << ( _gameOptions.Modes( GAME_CHEATS ) ? "on" : "off" ) << std::endl;
 
     os << std::endl << "# should auto save be performed at the beginning of the turn instead of the end of the turn: on/off" << std::endl;
     os << "auto save at the beginning of the turn = " << ( _gameOptions.Modes( GAME_AUTO_SAVE_AT_BEGINNING_OF_TURN ) ? "on" : "off" ) << std::endl;
@@ -779,6 +787,16 @@ void Settings::setTextSupportMode( const bool enable )
     }
 }
 
+void Settings::setCheatsEnabled( const bool enable )
+{
+    if ( enable ) {
+        _gameOptions.SetModes( GAME_CHEATS );
+    }
+    else {
+        _gameOptions.ResetModes( GAME_CHEATS );
+    }
+}
+
 void Settings::set3DAudio( const bool enable )
 {
     if ( enable ) {
@@ -873,6 +891,11 @@ bool Settings::isMonochromeCursorEnabled() const
 bool Settings::isTextSupportModeEnabled() const
 {
     return _gameOptions.Modes( GAME_TEXT_SUPPORT_MODE );
+}
+
+bool Settings::areCheatsEnabled() const
+{
+    return _gameOptions.Modes( GAME_CHEATS );
 }
 
 bool Settings::is3DAudioEnabled() const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -191,6 +191,7 @@ public:
     bool isPriceOfLoyaltySupported() const;
     bool isMonochromeCursorEnabled() const;
     bool isTextSupportModeEnabled() const;
+    bool areCheatsEnabled() const;
     bool is3DAudioEnabled() const;
     bool isSystemInfoEnabled() const;
     bool isAutoSaveAtBeginningOfTurnEnabled() const;
@@ -263,6 +264,7 @@ public:
     void setFullScreen( const bool enable );
     void setMonochromeCursor( const bool enable );
     void setTextSupportMode( const bool enable );
+    void setCheatsEnabled( const bool enable );
     void set3DAudio( const bool enable );
     void setVSync( const bool enable );
     void setSystemInfo( const bool enable );


### PR DESCRIPTION
## Summary
- switch cheat words to numeric codes
- expand cheat functionality: spawn Black Dragons, max hero skills, infinite moves, instant win, spell refill, build all buildings
- expose SetMovePoints and GameOver::SetResult helpers
- document numeric cheat list in README

## Testing
- `make -j$(nproc --ignore=1)`