### PR TITLE
Add cheat for upgraded units

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -100,6 +100,7 @@ When active, type one of the following numeric codes during gameplay:
 * **99999** – reveal the entire world map
 * **10000** – gain a large amount of all resources
 * **32167** – add five Black Dragons to the focused hero
+* **24680** – fill the focused hero's army with upgraded units from their faction (levels 2–6)
 * **1234** – max out the focused hero's primary skills
 * **654321** – learn every secondary skill at expert level
 * **11111** – give the focused hero unlimited movement points for the turn

--- a/src/fheroes2/game/game_cheats.cpp
+++ b/src/fheroes2/game/game_cheats.cpp
@@ -20,18 +20,19 @@
 #include "game_cheats.h"
 
 #include <SDL2/SDL.h>
-#include "logging.h"
-#include "settings.h"
-#include "world.h"
-#include "kingdom.h"
-#include "resource.h"
-#include "game_interface.h"
-#include "heroes.h"
+
 #include "castle.h"
+#include "game_interface.h"
+#include "game_over.h"
+#include "heroes.h"
+#include "kingdom.h"
+#include "logging.h"
 #include "monster.h"
+#include "resource.h"
+#include "settings.h"
 #include "spell.h"
 #include "spell_storage.h"
-#include "game_over.h"
+#include "world.h"
 
 namespace GameCheats
 {
@@ -66,6 +67,19 @@ namespace GameCheats
                 DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: black dragons" );
                 if ( Heroes * hero = Interface::GetFocusHeroes() ) {
                     hero->GetArmy().JoinTroop( Monster::BLACK_DRAGON, 5, true );
+                }
+                buffer.clear();
+            }
+            else if ( buffer.find( "24680" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: upgraded army" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    const int race = hero->GetRace();
+                    const uint32_t dwellings[] = { DWELLING_UPGRADE2, DWELLING_UPGRADE3, DWELLING_UPGRADE4, DWELLING_UPGRADE5, DWELLING_UPGRADE7 };
+                    for ( const uint32_t dw : dwellings ) {
+                        const Monster monster( race, dw );
+                        if ( monster.isValid() )
+                            hero->GetArmy().JoinTroop( monster, 5, true );
+                    }
                 }
                 buffer.clear();
             }
@@ -160,4 +174,3 @@ namespace GameCheats
         checkBuffer();
     }
 }
-


### PR DESCRIPTION
## Summary
- add cheat code `24680` to grant a hero all upgraded units of their faction
- document the new cheat in the cheats section
- refine logic so the cheat fills hero slots with upgraded units from tiers 2–6

## Testing
- `make -j2` *(failed: build interrupted due to time)*