### PR TITLE
Add alternative map reveal cheat

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -98,6 +98,7 @@ Cheat support can be enabled by setting `cheats = on` in `fheroes2.cfg` or by to
 When active, type one of the following numeric codes during gameplay:
 
 * **99999** – reveal the entire world map
+* **55555** – clear fog across the entire map
 * **10000** – gain a large amount of all resources
 * **32167** – add five Black Dragons to the focused hero
 * **24680** – replace the focused hero's army with upgraded units from tiers 2–6 of their faction

--- a/src/fheroes2/game/game_cheats.cpp
+++ b/src/fheroes2/game/game_cheats.cpp
@@ -34,6 +34,7 @@
 #include "spell.h"
 #include "spell_storage.h"
 #include "world.h"
+#include "interface_gamearea.h"
 
 namespace GameCheats
 {
@@ -50,6 +51,12 @@ namespace GameCheats
             if ( buffer.find( "99999" ) != std::string::npos ) {
                 DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: reveal map" );
                 World::Get().ClearFog( conf.CurrentColor() );
+                buffer.clear();
+            }
+            else if ( buffer.find( "55555" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: reveal all fog" );
+                World::Get().RevealMap( conf.CurrentColor() );
+                Interface::GameArea::updateMapFogDirections();
                 buffer.clear();
             }
             else if ( buffer.find( "10000" ) != std::string::npos ) {

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -955,6 +955,15 @@ void World::ClearFog( int colors ) const
     map_captureobj.ClearFog( colors );
 }
 
+void World::RevealMap( int colors ) const
+{
+    colors = Players::GetPlayerFriends( colors );
+
+    for ( Maps::Tile & tile : vec_tiles ) {
+        tile.ClearFog( colors );
+    }
+}
+
 const UltimateArtifact & World::GetUltimateArtifact() const
 {
     return ultimate_artifact;

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -383,6 +383,7 @@ public:
 
     void ActionForMagellanMaps( int color );
     void ClearFog( int color ) const;
+    void RevealMap( int color ) const;
 
     bool KingdomIsWins( const Kingdom & kingdom, const uint32_t wins ) const;
     bool KingdomIsLoss( const Kingdom & kingdom, const uint32_t loss ) const;


### PR DESCRIPTION
## Summary
- add `RevealMap` method to clear fog on all tiles
- expose new cheat code `55555` to clear fog across map
- document `55555` cheat in README

## Testing
- `bash script/tools/check_code_format.sh` *(fails: clang-format-diff not found)*
- `bash script/tools/check_copyright_headers.sh`