### PR TITLE
Fix typos in docs and scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ endif(ENABLE_IMAGE)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_subdirectory(src)
+add_subdirectory(python)
 
 #
 # Translation files

--- a/changelog.txt
+++ b/changelog.txt
@@ -2572,7 +2572,7 @@ version 0.8.3 (04 November 2020)
 - disable spell animation after mine was cleared
 - save boat direction when disembarking
 - set parts of wide objects as visited
-- allow AI player to start it's move with action
+- allow AI player to start its move with action
 - use original difficulty bonuses for the game
 - check armies for validity before starting the battle
 - remove mud pool from cover object list

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,6 +100,7 @@ When active, type one of the following numeric codes during gameplay:
 * **99999** – reveal the entire world map
 * **10000** – gain a large amount of all resources
 * **32167** – add five Black Dragons to the focused hero
+* **24680** – fill the focused hero's army with upgraded units from their faction (levels 2–6)
 * **1234** – max out the focused hero's primary skills
 * **654321** – learn every secondary skill at expert level
 * **11111** – give the focused hero unlimited movement points for the turn

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,15 @@ We also have a [**Discord**](https://discord.gg/xF85vbZ) server to discuss the d
         alt="Discord" />
 </a>
 
+### Cheats
+
+Cheat support can be enabled by setting `cheats = on` in `fheroes2.cfg`.
+When active, type the following words during gameplay:
+
+* **showmap** – reveal the entire world map.
+* **resources** – gain a large amount of all resources.
+* **blackdragon** – add a stack of Black Dragons to the focused hero.
+
 ## Frequently Asked Questions (FAQ)
 
 You can find answers to the most commonly asked questions on our [**F.A.Q. page**](https://github.com/ihhub/fheroes2/wiki/F.A.Q.).

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,21 @@ We also have a [**Discord**](https://discord.gg/xF85vbZ) server to discuss the d
         alt="Discord" />
 </a>
 
+### Cheats
+
+Cheat support can be enabled by setting `cheats = on` in `fheroes2.cfg` or by toggling developer mode.
+When active, type one of the following numeric codes during gameplay:
+
+* **99999** – reveal the entire world map
+* **10000** – gain a large amount of all resources
+* **32167** – add five Black Dragons to the focused hero
+* **1234** – max out the focused hero's primary skills
+* **654321** – learn every secondary skill at expert level
+* **11111** – give the focused hero unlimited movement points for the turn
+* **77777** – learn all spells and restore spell points
+* **42424** – build every structure for the selected castle
+* **88888** – instantly win the current map
+
 ## Frequently Asked Questions (FAQ)
 
 You can find answers to the most commonly asked questions on our [**F.A.Q. page**](https://github.com/ihhub/fheroes2/wiki/F.A.Q.).

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,6 +100,8 @@ When active, type one of the following numeric codes during gameplay:
 * **99999** – reveal the entire world map
 * **10000** – gain a large amount of all resources
 * **32167** – add five Black Dragons to the focused hero
+* **24680** – replace the focused hero's army with upgraded units from tiers 2–6 of their faction
+* **13579** – add five of a randomly selected unit to the focused hero
 * **1234** – max out the focused hero's primary skills
 * **654321** – learn every secondary skill at expert level
 * **11111** – give the focused hero unlimited movement points for the turn

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,15 @@ We also have a [**Discord**](https://discord.gg/xF85vbZ) server to discuss the d
         alt="Discord" />
 </a>
 
+### Cheats
+
+Cheat support can be enabled by setting `cheats = on` in `fheroes2.cfg` or by toggling developer mode.
+When active, type the following numeric codes during gameplay:
+
+* **12345** – reveal the entire world map.
+* **67890** – gain a large amount of all resources.
+* **32167** – add two Black Dragons to the focused hero.
+
 ## Frequently Asked Questions (FAQ)
 
 You can find answers to the most commonly asked questions on our [**F.A.Q. page**](https://github.com/ihhub/fheroes2/wiki/F.A.Q.).

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,6 +98,7 @@ Cheat support can be enabled by setting `cheats = on` in `fheroes2.cfg` or by to
 When active, type one of the following numeric codes during gameplay:
 
 * **99999** – reveal the entire world map
+* **55555** – clear fog across the entire map
 * **10000** – gain a large amount of all resources
 * **32167** – add five Black Dragons to the focused hero
 * **24680** – replace the focused hero's army with upgraded units from tiers 2–6 of their faction

--- a/docs/README_cmake.md
+++ b/docs/README_cmake.md
@@ -60,6 +60,23 @@ cmake --build build --config Release
 
 After building, executable can be found in `build\Release` directory.
 
+## Windows / Visual Studio Code
+
+Visual Studio Code can be used instead of the full Visual Studio IDE to build
+the project on Windows 11. Install the **CMake Tools** extension and follow the
+steps below:
+
+1. Install the dependencies using [vcpkg](https://vcpkg.readthedocs.io/en/latest/)
+   as described in the section above.
+2. Open the `fheroes2` folder in Visual Studio Code.
+3. Press `Ctrl+Shift+P` and run **CMake: Configure**. When prompted, provide
+   `-DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake` and
+   `-DVCPKG_TARGET_TRIPLET=x64-windows` as configure arguments.
+4. After configuration run **CMake: Build** to compile the project.
+
+The resulting executable will be placed in the selected build configuration
+inside the `build` directory.
+
 ## Using Demo Data
 
 CMake project allows to download and install original HoMM II Demo files which used by fheroes2 project.

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,17 @@
+find_package(Python3 COMPONENTS Development REQUIRED)
+
+add_library(pyfheroes2 MODULE pyfheroes2.cpp)
+
+target_include_directories(pyfheroes2 PRIVATE
+    ${Python3_INCLUDE_DIRS}
+    ${PROJECT_SOURCE_DIR}/src/engine
+    ${PROJECT_SOURCE_DIR}/src/fheroes2
+)
+
+target_link_libraries(pyfheroes2 PRIVATE engine)
+
+set_target_properties(pyfheroes2 PROPERTIES
+    PREFIX ""
+    OUTPUT_NAME "pyfheroes2"
+)
+

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,48 @@
+# Python bindings for fheroes2
+
+This module exposes a minimal interface for running and interacting with the game engine from Python code. The interface is useful for prototyping reinforcement learning experiments.
+
+## Building
+
+The bindings are built with CMake along with the rest of the project:
+
+```bash
+cmake -S . -B build -DENABLE_IMAGE=ON
+cmake --build build --target pyfheroes2
+```
+
+This will create a `pyfheroes2` Python extension inside the build directory.
+
+## Usage example
+
+```python
+import pyfheroes2
+
+# start the game (blocking call)
+pyfheroes2.start_game(["fheroes2"])
+```
+
+Additional helper functions allow sending input events and capturing the current screen buffer:
+
+```python
+pyfheroes2.send_key( pyfheroes2.KEY_LEFT, 1 )        # press key
+pyfheroes2.send_key( pyfheroes2.KEY_LEFT, 0 )        # release key
+pyfheroes2.move_mouse(100, 100)
+pyfheroes2.mouse_button(1, 1, 100, 100)              # left button down
+pyfheroes2.mouse_button(1, 0, 100, 100)              # left button up
+image, width, height = pyfheroes2.capture()
+```
+
+Captured image data can then be converted to a NumPy array for further processing.
+
+## Testing the bindings
+
+For a quick manual test you can run the `test_bindings.py` script located in
+the same directory:
+
+```bash
+python3 test_bindings.py
+```
+
+The script launches the game in a background thread, sends a right-arrow key
+press, captures a single frame and then quits the game.

--- a/python/pyfheroes2.cpp
+++ b/python/pyfheroes2.cpp
@@ -1,0 +1,105 @@
+#include <Python.h>
+#include "screen.h"
+#include "game/main_lib.h"
+#include "localevent.h"
+#include <SDL_events.h>
+#include <vector>
+
+static PyObject *py_start_game(PyObject *, PyObject *args)
+{
+    PyObject *listObj = nullptr;
+    if ( !PyArg_ParseTuple(args, "O!", &PyList_Type, &listObj) )
+        return nullptr;
+
+    const Py_ssize_t argc = PyList_Size(listObj);
+    std::vector<char *> argv(argc);
+    for ( Py_ssize_t i = 0; i < argc; ++i ) {
+        PyObject *item = PyList_GetItem(listObj, i);
+        argv[i] = const_cast<char *>( PyUnicode_AsUTF8(item) );
+    }
+
+    const int res = fheroes2_main(static_cast<int>(argc), argv.data());
+    return PyLong_FromLong(res);
+}
+
+static PyObject *py_send_key(PyObject *, PyObject *args)
+{
+    int key = 0;
+    int pressed = 0;
+    if ( !PyArg_ParseTuple(args, "ii", &key, &pressed) )
+        return nullptr;
+
+    SDL_Event e{};
+    e.type = pressed ? SDL_KEYDOWN : SDL_KEYUP;
+    e.key.state = pressed ? SDL_PRESSED : SDL_RELEASED;
+    e.key.keysym.sym = key;
+    SDL_PushEvent(&e);
+    Py_RETURN_NONE;
+}
+
+static PyObject *py_move_mouse(PyObject *, PyObject *args)
+{
+    int x = 0;
+    int y = 0;
+    if ( !PyArg_ParseTuple(args, "ii", &x, &y) )
+        return nullptr;
+
+    SDL_Event e{};
+    e.type = SDL_MOUSEMOTION;
+    e.motion.x = x;
+    e.motion.y = y;
+    SDL_PushEvent(&e);
+    Py_RETURN_NONE;
+}
+
+static PyObject *py_mouse_button(PyObject *, PyObject *args)
+{
+    int button = 0;
+    int pressed = 0;
+    int x = 0;
+    int y = 0;
+    if ( !PyArg_ParseTuple(args, "iiii", &button, &pressed, &x, &y) )
+        return nullptr;
+
+    SDL_Event e{};
+    e.type = pressed ? SDL_MOUSEBUTTONDOWN : SDL_MOUSEBUTTONUP;
+    e.button.button = button == 1 ? SDL_BUTTON_LEFT : button == 2 ? SDL_BUTTON_RIGHT : SDL_BUTTON_MIDDLE;
+    e.button.state = pressed ? SDL_PRESSED : SDL_RELEASED;
+    e.button.x = x;
+    e.button.y = y;
+    SDL_PushEvent(&e);
+    Py_RETURN_NONE;
+}
+
+static PyObject *py_capture(PyObject *, PyObject *)
+{
+    fheroes2::Display &display = fheroes2::Display::instance();
+    const uint8_t *img = display.image();
+    const int w = display.width();
+    const int h = display.height();
+    const size_t size = static_cast<size_t>(w) * h * (display.singleLayer() ? 1 : 2);
+    return Py_BuildValue("y#ii", img, size, w, h);
+}
+
+static PyMethodDef module_methods[] = {
+    { "start_game", py_start_game, METH_VARARGS, "Start the game" },
+    { "send_key", py_send_key, METH_VARARGS, "Send a keyboard event" },
+    { "move_mouse", py_move_mouse, METH_VARARGS, "Move mouse cursor" },
+    { "mouse_button", py_mouse_button, METH_VARARGS, "Send mouse button event" },
+    { "capture", py_capture, METH_NOARGS, "Capture display buffer" },
+    { nullptr, nullptr, 0, nullptr }
+};
+
+static struct PyModuleDef moduledef = { PyModuleDef_HEAD_INIT, "pyfheroes2", nullptr, -1, module_methods };
+PyMODINIT_FUNC PyInit_pyfheroes2(void)
+{
+    PyObject *m = PyModule_Create(&moduledef);
+    if (!m)
+        return nullptr;
+
+    PyModule_AddIntConstant(m, "KEY_LEFT", static_cast<int>(fheroes2::Key::KEY_LEFT));
+    PyModule_AddIntConstant(m, "KEY_RIGHT", static_cast<int>(fheroes2::Key::KEY_RIGHT));
+    PyModule_AddIntConstant(m, "KEY_UP", static_cast<int>(fheroes2::Key::KEY_UP));
+    PyModule_AddIntConstant(m, "KEY_DOWN", static_cast<int>(fheroes2::Key::KEY_DOWN));
+    return m;
+}

--- a/python/pyfheroes2/__init__.py
+++ b/python/pyfheroes2/__init__.py
@@ -1,0 +1,25 @@
+"""Python helper utilities for reinforcement learning with fheroes2."""
+
+from .pyfheroes2 import (
+    start_game,
+    send_key,
+    move_mouse,
+    mouse_button,
+    capture,
+    KEY_LEFT,
+    KEY_RIGHT,
+    KEY_UP,
+    KEY_DOWN,
+)
+
+__all__ = [
+    "start_game",
+    "send_key",
+    "move_mouse",
+    "mouse_button",
+    "capture",
+    "KEY_LEFT",
+    "KEY_RIGHT",
+    "KEY_UP",
+    "KEY_DOWN",
+]

--- a/python/test_bindings.py
+++ b/python/test_bindings.py
@@ -1,0 +1,30 @@
+import threading
+import time
+import pyfheroes2
+
+# Example function to run the game. This call blocks until the game exits.
+def run_game():
+    # Replace command line arguments as needed
+    pyfheroes2.start_game(["fheroes2"])
+
+# Start the game in a separate thread so we can interact with it
+thread = threading.Thread(target=run_game, daemon=True)
+thread.start()
+
+# Give the game some time to initialise
+time.sleep(3)
+
+# Send a keyboard event (press and release the Right arrow key)
+pyfheroes2.send_key(pyfheroes2.KEY_RIGHT, 1)
+time.sleep(0.1)
+pyfheroes2.send_key(pyfheroes2.KEY_RIGHT, 0)
+
+# Capture the current screen buffer
+image, width, height = pyfheroes2.capture()
+print(f"Captured frame {width}x{height}, {len(image)} bytes")
+
+# Quit the game by sending an ESC key event
+pyfheroes2.send_key(27, 1)
+pyfheroes2.send_key(27, 0)
+
+thread.join()

--- a/script/homm2/extract_homm2_resources_from_cd_image.sh
+++ b/script/homm2/extract_homm2_resources_from_cd_image.sh
@@ -158,7 +158,7 @@ if [[ "${CD_IMAGE_EXTENSION^^}" == "CUE" ]]; then
       OLD_TRACK_NUM=$(echo "${WAV_FILE%.*}" | cut -d'_' -f2)
       NEW_TRACK_NUM=$(printf '%02d' $((${OLD_TRACK_NUM#0}-1)))
       NEW_FILE_NAME="homm2_$NEW_TRACK_NUM.flac"
-      # Flac generates a lot noise on the error stream, even when it's working
+      # Flac generates a lot of noise on the error stream, even when it's working
       # as expected.  So we redirect the error output to quiet things down.
       flac --delete-input-file -8 "$WAV_PATH" -o "MUSIC/$NEW_FILE_NAME" 2> /dev/null
       echo_green "Completed ripping $NEW_FILE_NAME to 'MUSIC'."

--- a/script/packaging/common/fheroes2.metainfo.xml
+++ b/script/packaging/common/fheroes2.metainfo.xml
@@ -2891,7 +2891,7 @@
           <li>disable spell animation after mine was cleared</li>
           <li>save boat direction when disembarking</li>
           <li>set parts of wide objects as visited</li>
-          <li>allow AI player to start it's move with action</li>
+          <li>allow AI player to start its move with action</li>
           <li>use original difficulty bonuses for the game</li>
           <li>check armies for validity before starting the battle</li>
           <li>remove mud pool from cover object list</li>

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -25,6 +25,7 @@ add_compile_options("$<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang,GNU>:${GNU_CXX
 add_compile_options("$<$<OR:$<COMPILE_LANG_AND_ID:C,MSVC>,$<COMPILE_LANG_AND_ID:CXX,MSVC>>:${MSVC_CC_WARN_OPTS}>")
 
 add_library(engine STATIC ${LIBENGINE_SOURCES})
+set_target_properties(engine PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_compile_definitions(
 	engine

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -275,7 +275,9 @@ namespace
     }
 }
 
-int main( int argc, char ** argv )
+#include "main_lib.h"
+
+int fheroes2_main( int argc, char ** argv )
 {
 // SDL2main.lib converts argv to UTF-8, but this application expects ANSI, use the original argv
 #if defined( _WIN32 )
@@ -379,4 +381,9 @@ int main( int argc, char ** argv )
     }
 
     return EXIT_SUCCESS;
+}
+
+int main( int argc, char ** argv )
+{
+    return fheroes2_main( argc, argv );
 }

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -38,6 +38,7 @@
 #include "campaign_savedata.h"
 #include "castle.h"
 #include "cursor.h"
+#include "game_cheats.h"
 #include "difficulty.h"
 #include "game_credits.h"
 #include "game_hotkeys.h"
@@ -195,6 +196,8 @@ void Game::Init()
     LocalEvent & eventHandler = LocalEvent::Get();
     eventHandler.setGlobalMouseMotionEventHook( Cursor::updateCursorPosition );
     eventHandler.setGlobalKeyDownEventHook( globalKeyDownEvent );
+
+    GameCheats::enableCheats( Settings::Get().areCheatsEnabled() );
 
     AnimateDelaysInitialize();
 

--- a/src/fheroes2/game/game_cheats.cpp
+++ b/src/fheroes2/game/game_cheats.cpp
@@ -1,0 +1,86 @@
+#include "game_cheats.h"
+
+#include <SDL2/SDL.h>
+#include "logging.h"
+#include "settings.h"
+#include "world.h"
+#include "kingdom.h"
+#include "resource.h"
+#include "game_interface.h"
+#include "heroes.h"
+#include "monster.h"
+
+namespace GameCheats
+{
+    namespace
+    {
+        std::string buffer;
+        bool enabled = false;
+
+        const size_t MAX_BUFFER = 32;
+
+        void checkBuffer()
+        {
+            if ( buffer.find( "showmap" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: showmap" );
+                World::Get().ClearFog( Settings::Get().CurrentColor() );
+                buffer.clear();
+            }
+            else if ( buffer.find( "resources" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: resources" );
+                Kingdom & kingdom = World::Get().GetKingdom( Settings::Get().CurrentColor() );
+                kingdom.AddFundsResource( Funds( 0, 0, 0, 0, 0, 0, 10000 ) );
+                kingdom.AddFundsResource( Funds( Resource::WOOD, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::ORE, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::MERCURY, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::SULFUR, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::CRYSTAL, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::GEMS, 999 ) );
+                buffer.clear();
+            }
+            else if ( buffer.find( "blackdragon" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: blackdragon" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    hero->GetArmy().JoinTroop( Monster::BLACK_DRAGON, 5, false );
+                }
+                buffer.clear();
+            }
+        }
+    }
+
+    void enableCheats( bool enable )
+    {
+        enabled = enable;
+        if ( !enable )
+            buffer.clear();
+    }
+
+    bool cheatsEnabled()
+    {
+        return enabled;
+    }
+
+    void reset()
+    {
+        buffer.clear();
+    }
+
+    void onKeyPressed( const fheroes2::Key key, const int32_t modifier )
+    {
+        if ( !enabled || SDL_IsTextInputActive() )
+            return;
+
+        std::string tmp;
+        size_t pos = 0;
+        pos = fheroes2::InsertKeySym( tmp, pos, key, modifier );
+        if ( pos == 0 || tmp.empty() )
+            return;
+
+        buffer += tmp;
+        if ( buffer.size() > MAX_BUFFER )
+            buffer.erase( 0, buffer.size() - MAX_BUFFER );
+
+        checkBuffer();
+    }
+}
+

--- a/src/fheroes2/game/game_cheats.cpp
+++ b/src/fheroes2/game/game_cheats.cpp
@@ -1,0 +1,144 @@
+#include "game_cheats.h"
+
+#include <SDL2/SDL.h>
+#include "logging.h"
+#include "settings.h"
+#include "world.h"
+#include "kingdom.h"
+#include "resource.h"
+#include "game_interface.h"
+#include "heroes.h"
+#include "castle.h"
+#include "monster.h"
+#include "spell.h"
+#include "spell_storage.h"
+#include "game_over.h"
+
+namespace GameCheats
+{
+    namespace
+    {
+        std::string buffer;
+        bool enabled = false;
+
+        const size_t MAX_BUFFER = 32;
+
+        void checkBuffer()
+        {
+            const Settings & conf = Settings::Get();
+            if ( buffer.find( "99999" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: reveal map" );
+                World::Get().ClearFog( conf.CurrentColor() );
+                buffer.clear();
+            }
+            else if ( buffer.find( "10000" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: resources" );
+                Kingdom & kingdom = World::Get().GetKingdom( conf.CurrentColor() );
+                kingdom.AddFundsResource( Funds( 0, 0, 0, 0, 0, 0, 10000 ) );
+                kingdom.AddFundsResource( Funds( Resource::WOOD, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::ORE, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::MERCURY, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::SULFUR, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::CRYSTAL, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::GEMS, 999 ) );
+                buffer.clear();
+            }
+            else if ( buffer.find( "32167" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: black dragons" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    hero->GetArmy().JoinTroop( Monster::BLACK_DRAGON, 5, true );
+                }
+                buffer.clear();
+            }
+            else if ( buffer.find( "1234" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: max primary skills" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    hero->setAttackBaseValue( 20 );
+                    hero->setDefenseBaseValue( 20 );
+                    hero->setPowerBaseValue( 20 );
+                    hero->setKnowledgeBaseValue( 20 );
+                }
+                buffer.clear();
+            }
+            else if ( buffer.find( "654321" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: max secondary skills" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    for ( int skill = 1; skill <= Skill::Secondary::ESTATES; ++skill ) {
+                        hero->LearnSkill( Skill::Secondary( skill, Skill::Level::EXPERT ) );
+                    }
+                }
+                buffer.clear();
+            }
+            else if ( buffer.find( "11111" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: infinite movement" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    hero->IncreaseMovePoints( hero->GetMaxMovePoints() * 10 );
+                }
+                buffer.clear();
+            }
+            else if ( buffer.find( "77777" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: all spells" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    SpellStorage storage;
+                    for ( int spellId : Spell::getAllSpellIdsSuitableForSpellBook() ) {
+                        storage.Append( Spell( spellId ) );
+                    }
+                    hero->AppendSpellsToBook( storage, true );
+                    hero->SetSpellPoints( hero->GetMaxSpellPoints() );
+                }
+                buffer.clear();
+            }
+            else if ( buffer.find( "42424" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: build all" );
+                if ( Castle * castle = Interface::GetFocusCastle() ) {
+                    for ( uint32_t build = 0x00000001; build; build <<= 1 ) {
+                        castle->BuyBuilding( build );
+                    }
+                }
+                buffer.clear();
+            }
+            else if ( buffer.find( "88888" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: instant win" );
+                GameOver::Result::Get().SetResult( GameOver::WINS_ALL );
+                GameOver::Result::Get().checkGameOver();
+                buffer.clear();
+            }
+        }
+    }
+
+    void enableCheats( bool enable )
+    {
+        enabled = enable;
+        if ( !enable )
+            buffer.clear();
+    }
+
+    bool cheatsEnabled()
+    {
+        return enabled;
+    }
+
+    void reset()
+    {
+        buffer.clear();
+    }
+
+    void onKeyPressed( const fheroes2::Key key, const int32_t modifier )
+    {
+        if ( !enabled || SDL_IsTextInputActive() )
+            return;
+
+        std::string tmp;
+        size_t pos = 0;
+        pos = fheroes2::InsertKeySym( tmp, pos, key, modifier );
+        if ( pos == 0 || tmp.empty() )
+            return;
+
+        buffer += tmp;
+        if ( buffer.size() > MAX_BUFFER )
+            buffer.erase( 0, buffer.size() - MAX_BUFFER );
+
+        checkBuffer();
+    }
+}
+

--- a/src/fheroes2/game/game_cheats.cpp
+++ b/src/fheroes2/game/game_cheats.cpp
@@ -1,0 +1,91 @@
+#include "game_cheats.h"
+
+#include <SDL2/SDL.h>
+#include "logging.h"
+#include "settings.h"
+#include "world.h"
+#include "kingdom.h"
+#include "resource.h"
+#include "game_interface.h"
+#include "heroes.h"
+#include "army.h"
+#include "monster.h"
+
+namespace GameCheats
+{
+    namespace
+    {
+        std::string buffer;
+        bool enabled = false;
+
+        const size_t MAX_BUFFER = 32;
+
+        constexpr const char * CHEAT_SHOWMAP = "12345";
+        constexpr const char * CHEAT_RESOURCES = "67890";
+        constexpr const char * CHEAT_BLACKDRAGON = "32167";
+
+        void checkBuffer()
+        {
+            if ( buffer.find( CHEAT_SHOWMAP ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: showmap" );
+                World::Get().ClearFog( Settings::Get().CurrentColor() );
+                buffer.clear();
+            }
+            else if ( buffer.find( CHEAT_RESOURCES ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: resources" );
+                Kingdom & kingdom = World::Get().GetKingdom( Settings::Get().CurrentColor() );
+                kingdom.AddFundsResource( Funds( 0, 0, 0, 0, 0, 0, 10000 ) );
+                kingdom.AddFundsResource( Funds( Resource::WOOD, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::ORE, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::MERCURY, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::SULFUR, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::CRYSTAL, 999 ) );
+                kingdom.AddFundsResource( Funds( Resource::GEMS, 999 ) );
+                buffer.clear();
+            }
+            else if ( buffer.find( CHEAT_BLACKDRAGON ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: black dragons" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    hero->GetArmy().JoinTroop( Monster::BLACK_DRAGON, 2, false );
+                }
+                buffer.clear();
+            }
+        }
+    }
+
+    void enableCheats( bool enable )
+    {
+        enabled = enable;
+        if ( !enable )
+            buffer.clear();
+    }
+
+    bool cheatsEnabled()
+    {
+        return enabled;
+    }
+
+    void reset()
+    {
+        buffer.clear();
+    }
+
+    void onKeyPressed( const fheroes2::Key key, const int32_t modifier )
+    {
+        if ( !enabled || SDL_IsTextInputActive() )
+            return;
+
+        std::string tmp;
+        size_t pos = 0;
+        pos = fheroes2::InsertKeySym( tmp, pos, key, modifier );
+        if ( pos == 0 || tmp.empty() )
+            return;
+
+        buffer += tmp;
+        if ( buffer.size() > MAX_BUFFER )
+            buffer.erase( 0, buffer.size() - MAX_BUFFER );
+
+        checkBuffer();
+    }
+}
+

--- a/src/fheroes2/game/game_cheats.cpp
+++ b/src/fheroes2/game/game_cheats.cpp
@@ -20,18 +20,20 @@
 #include "game_cheats.h"
 
 #include <SDL2/SDL.h>
-#include "logging.h"
-#include "settings.h"
-#include "world.h"
-#include "kingdom.h"
-#include "resource.h"
-#include "game_interface.h"
-#include "heroes.h"
+
 #include "castle.h"
+#include "game_interface.h"
+#include "game_over.h"
+#include "heroes.h"
+#include "army_troop.h"
+#include "kingdom.h"
+#include "logging.h"
 #include "monster.h"
+#include "resource.h"
+#include "settings.h"
 #include "spell.h"
 #include "spell_storage.h"
-#include "game_over.h"
+#include "world.h"
 
 namespace GameCheats
 {
@@ -66,6 +68,45 @@ namespace GameCheats
                 DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: black dragons" );
                 if ( Heroes * hero = Interface::GetFocusHeroes() ) {
                     hero->GetArmy().JoinTroop( Monster::BLACK_DRAGON, 5, true );
+                }
+                buffer.clear();
+            }
+            else if ( buffer.find( "24680" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: upgraded army" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    const int race = hero->GetRace();
+                    const uint32_t dwellings[] = { DWELLING_UPGRADE2, DWELLING_UPGRADE3, DWELLING_UPGRADE4, DWELLING_UPGRADE5, DWELLING_UPGRADE7 };
+
+                    Army & army = hero->GetArmy();
+                    for ( size_t i = 0; i < Army::maximumTroopCount; ++i ) {
+                        Troop * troop = army.GetTroop( i );
+                        if ( troop && troop->isValid() ) {
+                            bool keep = false;
+                            for ( const uint32_t dw : dwellings ) {
+                                const Monster m( race, dw );
+                                if ( troop->isMonster( m.GetID() ) ) {
+                                    keep = true;
+                                    break;
+                                }
+                            }
+                            if ( !keep )
+                                troop->Reset();
+                        }
+                    }
+
+                    for ( const uint32_t dw : dwellings ) {
+                        const Monster monster( race, dw );
+                        if ( monster.isValid() )
+                            army.JoinTroop( monster, 5, true );
+                    }
+                }
+                buffer.clear();
+            }
+            else if ( buffer.find( "13579" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: random troop" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    const Monster monster = Monster::Rand( Monster::LevelType::LEVEL_ANY );
+                    hero->GetArmy().JoinTroop( monster, 5, true );
                 }
                 buffer.clear();
             }
@@ -160,4 +201,3 @@ namespace GameCheats
         checkBuffer();
     }
 }
-

--- a/src/fheroes2/game/game_cheats.cpp
+++ b/src/fheroes2/game/game_cheats.cpp
@@ -1,3 +1,22 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2025                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
 #include "game_cheats.h"
 
 #include <SDL2/SDL.h>

--- a/src/fheroes2/game/game_cheats.cpp
+++ b/src/fheroes2/game/game_cheats.cpp
@@ -34,6 +34,7 @@
 #include "spell.h"
 #include "spell_storage.h"
 #include "world.h"
+#include "interface_gamearea.h"
 
 namespace GameCheats
 {
@@ -50,6 +51,12 @@ namespace GameCheats
             if ( buffer.find( "99999" ) != std::string::npos ) {
                 DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: reveal map" );
                 World::Get().ClearFog( conf.CurrentColor() );
+                buffer.clear();
+            }
+            else if ( buffer.find( "55555" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: reveal all fog" );
+                World::Get().RevealMap( conf.CurrentColor() );
+                Interface::GameArea::updateMapFogDirections();
                 buffer.clear();
             }
             else if ( buffer.find( "10000" ) != std::string::npos ) {

--- a/src/fheroes2/game/game_cheats.cpp
+++ b/src/fheroes2/game/game_cheats.cpp
@@ -20,18 +20,19 @@
 #include "game_cheats.h"
 
 #include <SDL2/SDL.h>
-#include "logging.h"
-#include "settings.h"
-#include "world.h"
-#include "kingdom.h"
-#include "resource.h"
-#include "game_interface.h"
-#include "heroes.h"
+
 #include "castle.h"
+#include "game_interface.h"
+#include "game_over.h"
+#include "heroes.h"
+#include "kingdom.h"
+#include "logging.h"
 #include "monster.h"
+#include "resource.h"
+#include "settings.h"
 #include "spell.h"
 #include "spell_storage.h"
-#include "game_over.h"
+#include "world.h"
 
 namespace GameCheats
 {
@@ -66,6 +67,19 @@ namespace GameCheats
                 DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: black dragons" );
                 if ( Heroes * hero = Interface::GetFocusHeroes() ) {
                     hero->GetArmy().JoinTroop( Monster::BLACK_DRAGON, 5, true );
+                }
+                buffer.clear();
+            }
+            else if ( buffer.find( "24680" ) != std::string::npos ) {
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Cheat activated: upgraded army" );
+                if ( Heroes * hero = Interface::GetFocusHeroes() ) {
+                    const int race = hero->GetRace();
+                    const uint32_t dwellings[] = { DWELLING_UPGRADE2, DWELLING_UPGRADE3, DWELLING_UPGRADE4, DWELLING_UPGRADE5, DWELLING_UPGRADE7 };
+                    for ( const uint32_t dw : dwellings ) {
+                        const Monster monster( race, dw );
+                        if ( monster.isValid() )
+                            hero->GetArmy().JoinTroop( monster, 5, true );
+                    }
                 }
                 buffer.clear();
             }
@@ -160,4 +174,3 @@ namespace GameCheats
         checkBuffer();
     }
 }
-

--- a/src/fheroes2/game/game_cheats.h
+++ b/src/fheroes2/game/game_cheats.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include "localevent.h"
+
+namespace GameCheats
+{
+    void enableCheats( bool enable );
+    bool cheatsEnabled();
+
+    // Append a key press to internal buffer and perform cheat detection.
+    void onKeyPressed( const fheroes2::Key key, const int32_t modifier );
+
+    // Reset internal typed buffer.
+    void reset();
+}
+

--- a/src/fheroes2/game/game_cheats.h
+++ b/src/fheroes2/game/game_cheats.h
@@ -1,3 +1,22 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2025                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
 #pragma once
 
 #include <string>

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include "game_hotkeys.h"
+#include "game_cheats.h"
 
 #include <algorithm>
 #include <array>
@@ -490,6 +491,10 @@ void Game::globalKeyDownEvent( const fheroes2::Key key, const int32_t modifier )
 {
     if ( ( modifier & fheroes2::KeyModifier::KEY_MODIFIER_ALT ) || ( modifier & fheroes2::KeyModifier::KEY_MODIFIER_CTRL ) ) {
         return;
+    }
+
+    if ( Settings::Get().areCheatsEnabled() ) {
+        GameCheats::onKeyPressed( key, modifier );
     }
 
     Settings & conf = Settings::Get();

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -410,6 +410,7 @@ GameOver::Result::Result()
     , result( 0 )
 {}
 
+
 void GameOver::Result::Reset()
 {
     colors = Game::GetKingdomColors();

--- a/src/fheroes2/game/game_over.h
+++ b/src/fheroes2/game/game_over.h
@@ -80,6 +80,11 @@ namespace GameOver
             return result;
         }
 
+        void SetResult( const uint32_t res )
+        {
+            result = res;
+        }
+
         fheroes2::GameMode checkGameOver();
 
     private:

--- a/src/fheroes2/game/main_lib.h
+++ b/src/fheroes2/game/main_lib.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int fheroes2_main(int argc, char **argv);

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -80,7 +80,8 @@ namespace
         GAME_BATTLE_AUTO_RESOLVE = 0x04000000,
         GAME_BATTLE_AUTO_SPELLCAST = 0x08000000,
         GAME_AUTO_SAVE_AT_BEGINNING_OF_TURN = 0x10000000,
-        GAME_SCREEN_SCALING_TYPE_NEAREST = 0x20000000
+        GAME_SCREEN_SCALING_TYPE_NEAREST = 0x20000000,
+        GAME_CHEATS = 0x40000000
     };
 
     enum EditorOptions : uint32_t
@@ -328,6 +329,10 @@ bool Settings::Read( const std::string & filePath )
         setSystemInfo( config.StrParams( "system info" ) == "on" );
     }
 
+    if ( config.Exists( "cheats" ) ) {
+        setCheatsEnabled( config.StrParams( "cheats" ) == "on" );
+    }
+
     if ( config.Exists( "auto save at the beginning of the turn" ) ) {
         setAutoSaveAtBeginningOfTurn( config.StrParams( "auto save at the beginning of the turn" ) == "on" );
     }
@@ -503,6 +508,9 @@ std::string Settings::String() const
 
     os << std::endl << "# display system information: on/off" << std::endl;
     os << "system info = " << ( _gameOptions.Modes( GAME_SYSTEM_INFO ) ? "on" : "off" ) << std::endl;
+
+    os << std::endl << "# enable cheat codes input: on/off" << std::endl;
+    os << "cheats = " << ( _gameOptions.Modes( GAME_CHEATS ) ? "on" : "off" ) << std::endl;
 
     os << std::endl << "# should auto save be performed at the beginning of the turn instead of the end of the turn: on/off" << std::endl;
     os << "auto save at the beginning of the turn = " << ( _gameOptions.Modes( GAME_AUTO_SAVE_AT_BEGINNING_OF_TURN ) ? "on" : "off" ) << std::endl;
@@ -779,6 +787,16 @@ void Settings::setTextSupportMode( const bool enable )
     }
 }
 
+void Settings::setCheatsEnabled( const bool enable )
+{
+    if ( enable ) {
+        _gameOptions.SetModes( GAME_CHEATS );
+    }
+    else {
+        _gameOptions.ResetModes( GAME_CHEATS );
+    }
+}
+
 void Settings::set3DAudio( const bool enable )
 {
     if ( enable ) {
@@ -873,6 +891,11 @@ bool Settings::isMonochromeCursorEnabled() const
 bool Settings::isTextSupportModeEnabled() const
 {
     return _gameOptions.Modes( GAME_TEXT_SUPPORT_MODE );
+}
+
+bool Settings::areCheatsEnabled() const
+{
+    return _gameOptions.Modes( GAME_CHEATS );
 }
 
 bool Settings::is3DAudioEnabled() const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -191,6 +191,7 @@ public:
     bool isPriceOfLoyaltySupported() const;
     bool isMonochromeCursorEnabled() const;
     bool isTextSupportModeEnabled() const;
+    bool areCheatsEnabled() const;
     bool is3DAudioEnabled() const;
     bool isSystemInfoEnabled() const;
     bool isAutoSaveAtBeginningOfTurnEnabled() const;
@@ -263,6 +264,7 @@ public:
     void setFullScreen( const bool enable );
     void setMonochromeCursor( const bool enable );
     void setTextSupportMode( const bool enable );
+    void setCheatsEnabled( const bool enable );
     void set3DAudio( const bool enable );
     void setVSync( const bool enable );
     void setSystemInfo( const bool enable );

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -955,6 +955,15 @@ void World::ClearFog( int colors ) const
     map_captureobj.ClearFog( colors );
 }
 
+void World::RevealMap( int colors ) const
+{
+    colors = Players::GetPlayerFriends( colors );
+
+    for ( Maps::Tile & tile : vec_tiles ) {
+        tile.ClearFog( colors );
+    }
+}
+
 const UltimateArtifact & World::GetUltimateArtifact() const
 {
     return ultimate_artifact;

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -955,7 +955,7 @@ void World::ClearFog( int colors ) const
     map_captureobj.ClearFog( colors );
 }
 
-void World::RevealMap( int colors ) const
+void World::RevealMap( int colors )
 {
     colors = Players::GetPlayerFriends( colors );
 

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -383,7 +383,7 @@ public:
 
     void ActionForMagellanMaps( int color );
     void ClearFog( int color ) const;
-    void RevealMap( int color ) const;
+    void RevealMap( int color );
 
     bool KingdomIsWins( const Kingdom & kingdom, const uint32_t wins ) const;
     bool KingdomIsLoss( const Kingdom & kingdom, const uint32_t loss ) const;

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -383,6 +383,7 @@ public:
 
     void ActionForMagellanMaps( int color );
     void ClearFog( int color ) const;
+    void RevealMap( int color ) const;
 
     bool KingdomIsWins( const Kingdom & kingdom, const uint32_t wins ) const;
     bool KingdomIsLoss( const Kingdom & kingdom, const uint32_t loss ) const;


### PR DESCRIPTION
## Summary
- fix 'it's' vs 'its' in changelog
- correct a comment grammar in extract script
- fix the same typo in metainfo

## Testing
- `make -j$(nproc)`