### PR TITLE
Fix typos and grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can find a complete list of all of our changes and enhancements in [**its ow
 
 Please follow the [**installation guide**](docs/INSTALL.md) to download and install fheroes2.
 
-[![Github Downloads](https://img.shields.io/github/downloads/ihhub/fheroes2/total.svg)](https://github.com/ihhub/fheroes2/releases)
+[![GitHub Downloads](https://img.shields.io/github/downloads/ihhub/fheroes2/total.svg)](https://github.com/ihhub/fheroes2/releases)
 
 ## Copyright
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -53,7 +53,7 @@ If you would like to build the project using CMake please follow the instruction
 
 ## Building the front end website
 
-We host the website on Github pages, which is a highly customized version of the
+We host the website on GitHub Pages, which is a highly customized version of the
 Jekyll static site engine. The instructions for developing the website can be
 found in the [**website local dev**](WEBSITE_LOCAL_DEV.md) guide.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ You can find a complete list of all of our changes and enhancements in [**its ow
 Please follow the [**installation guide**](INSTALL.md) to download and install fheroes2.
 
 <a href="https://github.com/ihhub/fheroes2/releases">
-    <img loading="lazy" width="106" height="20" src="https://img.shields.io/github/downloads/ihhub/fheroes2/total.svg" alt="Github Downloads">
+    <img loading="lazy" width="106" height="20" src="https://img.shields.io/github/downloads/ihhub/fheroes2/total.svg" alt="GitHub Downloads">
 </a>
 
 ## Copyright

--- a/docs/README_PSV.md
+++ b/docs/README_PSV.md
@@ -9,9 +9,9 @@ fheroes2 requires data files from the original Heroes of Might and Magic II.
 Copy HEROES2.AGG and HEROES2X.AGG (if you own Price of Loyalty expansion) from the original games "DATA" folder into
 "ux0:data/fheroes2/data" and everything from "MAPS" folder into "ux0:data/fheroes2/maps".
 
-Music files in OGG format (from GoG release of the game) should be placed into the "ux0:data/fheroes2/music/" folder.
+Music files in OGG format (from GOG release of the game) should be placed into the "ux0:data/fheroes2/music/" folder.
 
-fheroes2 supports ingame cinematics. To play into and/or other videos, make sure that all of "*.SMK" files are placed
+fheroes2 supports in-game cinematics. To play intro and/or other videos, make sure that all of "*.SMK" files are placed
 inside "ux0:data/fheroes2/heroes2/anim/" folder.
 
 [rePatch reDux0](https://github.com/dots-tb/rePatch-reDux0) OR [FdFix](https://github.com/TheOfficialFloW/FdFix) plugin

--- a/docs/README_android.md
+++ b/docs/README_android.md
@@ -17,7 +17,7 @@ ZIP archive created by you in the previous step to extract the assets of the ori
 Depending on your version of Heroes 2, the music files that need to be placed in the "MUSIC" directory can either be on your
 original CD or in the installation folder (GOG and Ubisoft).
 
-Ingame cinematics are supported by fheroes2 and for these to be supported it is necessary to have them in the "ANIM" folder.
+In-game cinematics are supported by fheroes2 and for these to be supported it is necessary to have them in the "ANIM" folder.
 Depending on your original version of Heroes 2 they can either be found on your CD, disc image or in a folder named "anim" in
 your Heroes 2 installation directory.
 
@@ -27,7 +27,7 @@ To simulate a right-click to get info on various items, you need to first touch 
 and then touch anywhere else on the screen. While holding the second finger, you can remove the first one from the screen
 and keep viewing the information on the item.
 
-By default normal adventure map scrolling on the borders of the screen is disabled. To pane the viewing area around you
+By default normal adventure map scrolling on the borders of the screen is disabled. To pan the viewing area around you
 need to press anywhere on the adventure map and slide around to change where you are viewing.
 
 During combat, actions (such as moving, attacking, or casting a spell) performed using the touchpad/touchscreen must be

--- a/docs/README_cmake.md
+++ b/docs/README_cmake.md
@@ -2,10 +2,10 @@
 
 ## Linux and macOS
 
-[**fheroes2**](README.md) can be built with CMake buildsystem. First, you need to install dependencies.
-For Linux and macOS follow to instructions as described above.
+[**fheroes2**](README.md) can be built with the CMake build system. First, you need to install dependencies.
+For Linux and macOS follow the instructions as described above.
 
-Next, you can configure the project with following commands:
+Next, you can configure the project with the following command:
 
 ```shell
 cmake -B build
@@ -17,35 +17,35 @@ After configuration let's build the project:
 cmake --build build
 ```
 
-After building, executable can be found in `build` directory.
+After building, the executable can be found in the `build` directory.
 
 ## Windows / Visual Studio
 
 For Windows you'll need Visual Studio 2019 with C++ support and
 [vcpkg package manager](https://vcpkg.readthedocs.io/en/latest/) for dependency management.
-Here quick and short instruction for deployment:
+Here is a quick and short instruction for deployment:
 
 ```shell
-# Clone vcpkg repository. For convenient, let's place it in C:\vcpkg directory, but it can be anywhere.
+# Clone vcpkg repository. For convenience, let's place it in C:\vcpkg directory, but it can be anywhere.
 git clone https://github.com/microsoft/vcpkg.git
 # Now initialize manager
 .\vcpkg\bootstrap-vcpkg.bat
 ```
 
-Your vcpkg is ready to install external libraries. Assuming that you use x64 system, let's install all needed dependencies:
+Your vcpkg is ready to install external libraries. Assuming you use an x64 system, let's install all needed dependencies:
 
 ```shell
 .\vcpkg\vcpkg --triplet x64-windows install sdl2 sdl2-image sdl2-mixer zlib
 ```
 
-If you planning to develop fheroes2 with Visual Studio, you may want to integrate vcpkg with it (requires elevated admin privileges).
-After following command Visual Studio automagically will find all required dependencies:
+If you plan to develop fheroes2 with Visual Studio, you may want to integrate vcpkg with it (requires elevated admin privileges).
+After running the following command Visual Studio will automatically find all required dependencies:
 
 ```shell
 .\vcpkg\vcpkg integrate install
 ```
 
-Now you are ready to configure the project. cd to fheroes2 directory and run `cmake` command (note for `-DCMAKE_TOOLCHAIN_FILE` and
+Now you are ready to configure the project. Change to the fheroes2 directory and run the `cmake` command (note the `-DCMAKE_TOOLCHAIN_FILE` and
 `-DVCPKG_TARGET_TRIPLET` options):
 
 ```shell
@@ -58,12 +58,12 @@ After configuration let's build the project:
 cmake --build build --config Release
 ```
 
-After building, executable can be found in `build\Release` directory.
+After building, the executable can be found in the `build\Release` directory.
 
 ## Using Demo Data
 
-CMake project allows to download and install original HoMM II Demo files which used by fheroes2 project.
-To do this please add `-DGET_HOMM2_DEMO=ON` to configuration options. For example:
+The CMake project allows you to download and install the original HoMM II Demo files which are used by the fheroes2 project.
+To do this, please add `-DGET_HOMM2_DEMO=ON` to the configuration options. For example:
 
 ```shell
 cmake -B build -DGET_HOMM2_DEMO=ON <some other options>

--- a/docs/README_switch.md
+++ b/docs/README_switch.md
@@ -18,7 +18,7 @@ You will need a copy of the official game to run this port.
 
 fheroes2 root directory is hardcoded as `/switch/fheroes2`. Put the game files there (specifically `ANIM`, `DATA`, `MAPS`
 and `MUSIC` folders), then copy over the `files` directory, as well as `fheroes2.nro`. If you have a Russian version from
-Buka Enternainment, you'll likely have `Anim2` folder instead. Rename it to `ANIM` if you wish use the Buka game data with
+Buka Entertainment, you'll likely have an `Anim2` folder instead. Rename it to `ANIM` if you wish to use the Buka game data with
 this port.
 
 At the end you should have the following directory tree on your SD card:

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -103,7 +103,7 @@ the program will need to be set to compile the MO file in the font encoding/char
 set to.
 
 For example, for German you will have to set font encoding to CP1252, while for Russian this would be CP1251. Later when submitting
-a pull request with your changes, you will have to save the PO file in UTF-8 encoding because this is what Github supports.
+a pull request with your changes, you will have to save the PO file in UTF-8 encoding because this is what GitHub supports.
 
 ### Sharing Your Translation Work
 
@@ -138,7 +138,7 @@ example creature names or castle buildings.
 
 ## Updating PO Templates and Translatable Strings in PO Files
 
-Currently all PO files are automatically updated with new strings after each commit that brings changes to the ingame text. If for whatever reason
+Currently all PO files are automatically updated with new strings after each commit that brings changes to the in-game text. If for whatever reason
 you still need to update strings locally, this can be achieved by running the command below in `src/dist/fheroes2` to generate a new portable object
 template (POT) file. Windows users will need to set up an environment that lets them run `make`, like Windows Subsystem for Linux (WSL) or
 [**Cygwin**](https://www.cygwin.com/)/[**MSYS2**](https://www.msys2.org/).

--- a/docs/deployments/WEB_DEPLOYMENT.md
+++ b/docs/deployments/WEB_DEPLOYMENT.md
@@ -1,12 +1,12 @@
 # Website Build and Deployment
 
 This document describes the end-to-end deployment strategy for the fheroes2 site deployment.
-We target Github Pages for hosting and leverage GitHub Actions for automation.
+We target GitHub Pages for hosting and leverage GitHub Actions for automation.
 
 ## Functionality
 
 * Builds the documentation site for the fheroes2 project
-* Deploys the site, along with WebAssembly build, to Github Pages on push.
+* Deploys the site, along with WebAssembly build, to GitHub Pages on push.
 * Allows end users to view the documentation via the web.
 * Allows end users to click a link and launch the game via the web.
 
@@ -50,7 +50,7 @@ sequenceDiagram
 
 * Listens for completion of the upstream `Make` workflow.
 * Pulls the latest GitHub Release and extracts the ZIP bundle.
-* Builds and Deploys the Github Pages with the bundle.
+* Builds and Deploys the GitHub Pages with the bundle.
 
 ## GitHub Workflows Summary
 
@@ -65,7 +65,7 @@ sequenceDiagram
 * Triggered on completion of `make.yml`
 * Builds Jekyll site
 * Downloads release
-* Deploys to Github Pages
+* Deploys to GitHub Pages
 
 ## Future Considerations
 

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -843,7 +843,7 @@ namespace
             return value;
         }
 
-        // Some objects do not loose their value drastically over distances. This allows AI heroes to keep focus on important targets.
+        // Some objects do not lose their value drastically over distances. This allows AI heroes to keep focus on important targets.
         double correctedDistance = distance * getDistanceModifier( objectType );
 
         // Distances should be corrected over time as AI heroes should focus on keeping important objects in focus.


### PR DESCRIPTION
## Summary
- fix Buka Entertainment typo and phrasing in Switch README
- clean up README_cmake wording
- correct "ingame" to "in-game" in translation guide

## Testing
- `bash script/tools/check_code_format.sh` *(fails: clang-format-diff not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cdea809108320a048e5df83631f38