### PR TITLE
Add basic Python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ endif(ENABLE_IMAGE)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_subdirectory(src)
+add_subdirectory(python)
 
 #
 # Translation files

--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ To assist with the graphical asset efforts of the project, please look at our [*
 
 If you would like to help translating the project, please read the [**translation guide**](docs/TRANSLATION.md).
 
+### Python bindings
+
+You can build a Python extension module exposing the game engine. Configure the
+project with CMake as usual and the `fheroes2` module will be created inside the
+`build` directory. It allows running the game directly from Python and querying
+basic information such as the engine version.
+
+Example usage:
+
+```python
+import fheroes2
+
+print("Engine version:", fheroes2.get_version())
+
+# Start the game. Arguments match the command line interface.
+fheroes2.run_game()
+```
+
 ### Developing fheroes2 documentation site
 
 To build the [website](https://ihhub.github.io/fheroes2/) from source, please follow

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,0 +1,47 @@
+find_package(Python3 COMPONENTS Development REQUIRED)
+
+set(PYFHEROES2_SOURCES
+    pyfheroes2.cpp
+)
+
+Python3_add_library(fheroes2_py MODULE ${PYFHEROES2_SOURCES})
+
+set_target_properties(fheroes2_py PROPERTIES
+    PREFIX ""
+    OUTPUT_NAME "fheroes2"
+)
+
+# Ensure PIC for shared library
+set_target_properties(fheroes2_py PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# Include engine headers
+target_include_directories(fheroes2_py PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/agg
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/ai
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/army
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/audio
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/battle
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/campaign
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/castle
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/dialog
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/editor
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/game
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/gui
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/h2d
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/heroes
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/image
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/kingdom
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/maps
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/monster
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/resource
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/spell
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/system
+    ${CMAKE_SOURCE_DIR}/src/fheroes2/world
+)
+
+# Link with fheroes2 core library and engine
+if(TARGET fheroes2core)
+    target_link_libraries(fheroes2_py PRIVATE fheroes2core engine Python3::Python)
+else()
+    target_link_libraries(fheroes2_py PRIVATE engine Python3::Python)
+endif()

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,26 @@
+# Python bindings for fheroes2
+
+This directory contains a minimal Python extension module exposing the `fheroes2` engine.
+
+## Building
+
+Use CMake to configure and build the project. The module is produced alongside the C++ binaries:
+
+```bash
+cmake -B build
+cmake --build build
+```
+
+After compilation the shared library `fheroes2$(python3-config --extension-suffix)` will be located in the `build/python` directory.
+You can either copy this file next to your scripts or adjust `PYTHONPATH`.
+
+## Example usage
+
+````python
+import fheroes2
+
+print("Version:", fheroes2.get_version())
+
+# Run the game with default arguments
+fheroes2.run_game()
+````

--- a/python/example.py
+++ b/python/example.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Minimal example showing how to launch fheroes2 from Python."""
+
+import fheroes2
+
+print("fheroes2 version:", fheroes2.get_version())
+
+# Start the game with no command line arguments.
+# You can pass parameters as you would on the command line,
+# for example: fheroes2.run_game("--map", "test.mp2")
+fheroes2.run_game()

--- a/python/pyfheroes2.cpp
+++ b/python/pyfheroes2.cpp
@@ -1,0 +1,56 @@
+#include <Python.h>
+#include "fheroes2/system/settings.h"
+#include <SDL_main.h>
+#include <vector>
+#include <string>
+
+static PyObject * py_get_version( PyObject *, PyObject * )
+{
+    const std::string ver = Settings::GetVersion();
+    return PyUnicode_FromString( ver.c_str() );
+}
+
+static PyObject * py_run_game( PyObject *, PyObject * args )
+{
+    if ( !PyTuple_Check( args ) ) {
+        PyErr_SetString( PyExc_TypeError, "arguments must be a tuple" );
+        return nullptr;
+    }
+
+    const Py_ssize_t argcPy = PyTuple_Size( args );
+    std::vector<char *> argv;
+    argv.reserve( static_cast<size_t>( argcPy ) + 1 );
+    argv.push_back( const_cast<char *>( "fheroes2" ) );
+
+    for ( Py_ssize_t i = 0; i < argcPy; ++i ) {
+        PyObject * item = PyTuple_GetItem( args, i );
+        if ( !PyUnicode_Check( item ) ) {
+            PyErr_SetString( PyExc_TypeError, "all arguments must be strings" );
+            return nullptr;
+        }
+        argv.push_back( const_cast<char *>( PyUnicode_AsUTF8( item ) ) );
+    }
+    argv.push_back( nullptr );
+
+    int result = SDL_main( static_cast<int>( argv.size() - 1 ), argv.data() );
+    return PyLong_FromLong( result );
+}
+
+static PyMethodDef fh2Methods[] = {
+    { "get_version", py_get_version, METH_NOARGS, "Get fheroes2 version string." },
+    { "run_game", py_run_game, METH_VARARGS, "Run fheroes2 with given arguments." },
+    { nullptr, nullptr, 0, nullptr }
+};
+
+static struct PyModuleDef fh2module = {
+    PyModuleDef_HEAD_INIT,
+    "fheroes2",   /* name of module */
+    "Python bindings for fheroes2.",
+    -1,
+    fh2Methods
+};
+
+PyMODINIT_FUNC PyInit_fheroes2( void )
+{
+    return PyModule_Create( &fh2module );
+}

--- a/python/pyfheroes2.cpp
+++ b/python/pyfheroes2.cpp
@@ -1,8 +1,10 @@
 #include <Python.h>
-#include "fheroes2/system/settings.h"
+#include "settings.h"
 #include <SDL_main.h>
 #include <vector>
 #include <string>
+
+extern "C" int main( int argc, char ** argv );
 
 static PyObject * py_get_version( PyObject *, PyObject * )
 {
@@ -32,7 +34,7 @@ static PyObject * py_run_game( PyObject *, PyObject * args )
     }
     argv.push_back( nullptr );
 
-    int result = SDL_main( static_cast<int>( argv.size() - 1 ), argv.data() );
+    int result = main( static_cast<int>( argv.size() - 1 ), argv.data() );
     return PyLong_FromLong( result );
 }
 

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -25,6 +25,7 @@ add_compile_options("$<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang,GNU>:${GNU_CXX
 add_compile_options("$<$<OR:$<COMPILE_LANG_AND_ID:C,MSVC>,$<COMPILE_LANG_AND_ID:CXX,MSVC>>:${MSVC_CC_WARN_OPTS}>")
 
 add_library(engine STATIC ${LIBENGINE_SOURCES})
+set_target_properties(engine PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_compile_definitions(
 	engine

--- a/src/fheroes2/CMakeLists.txt
+++ b/src/fheroes2/CMakeLists.txt
@@ -20,6 +20,52 @@
 
 file(GLOB_RECURSE FHEROES2_SOURCES CONFIGURE_DEPENDS *.cpp)
 
+add_library(fheroes2core STATIC ${FHEROES2_SOURCES})
+
+set_target_properties(fheroes2core PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+target_compile_definitions(
+        fheroes2core
+        PRIVATE
+        # MSVC: suppress deprecation warnings
+        $<$<OR:$<COMPILE_LANG_AND_ID:C,MSVC>,$<COMPILE_LANG_AND_ID:CXX,MSVC>>:_CRT_SECURE_NO_WARNINGS>
+        $<$<CONFIG:Debug>:WITH_DEBUG>
+        $<$<BOOL:${MACOS_APP_BUNDLE}>:MACOS_APP_BUNDLE>
+        )
+
+target_include_directories(
+        fheroes2core
+        PRIVATE
+        agg
+        ai
+        army
+        audio
+        battle
+        campaign
+        castle
+        dialog
+        editor
+        game
+        gui
+        h2d
+        heroes
+        image
+        kingdom
+        maps
+        monster
+        resource
+        spell
+        system
+        world
+        )
+
+target_link_libraries(
+        fheroes2core
+        PUBLIC
+        engine
+        ${USE_SDL_VERSION}::${USE_SDL_VERSION}main
+        )
+
 add_compile_options("$<$<COMPILE_LANG_AND_ID:C,AppleClang,Clang,GNU>:${GNU_CC_WARN_OPTS}>")
 add_compile_options("$<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang,GNU>:${GNU_CXX_WARN_OPTS}>")
 add_compile_options("$<$<OR:$<COMPILE_LANG_AND_ID:C,MSVC>,$<COMPILE_LANG_AND_ID:CXX,MSVC>>:${MSVC_CC_WARN_OPTS}>")
@@ -28,7 +74,7 @@ if(MACOS_APP_BUNDLE)
 	set(FHEROES2_ICON ${CMAKE_CURRENT_SOURCE_DIR}/../resources/fheroes2.icns)
 	set_source_files_properties(${FHEROES2_ICON} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
-	add_executable(fheroes2 MACOSX_BUNDLE ${FHEROES2_ICON} ${FHEROES2_SOURCES} ${TRANSLATION_DATA})
+        add_executable(fheroes2 MACOSX_BUNDLE ${FHEROES2_ICON} ${TRANSLATION_DATA})
 
 	target_compile_definitions(
 		fheroes2
@@ -37,7 +83,7 @@ if(MACOS_APP_BUNDLE)
 		$<$<BOOL:${MACOS_APP_BUNDLE}>:MACOS_APP_BUNDLE>
 		)
 
-	target_link_libraries(fheroes2 "-framework CoreFoundation")
+        target_link_libraries(fheroes2 fheroes2core "-framework CoreFoundation")
 
 	set_target_properties(fheroes2 PROPERTIES MACOSX_BUNDLE_BUNDLE_NAME ${CMAKE_PROJECT_NAME})
 	set_target_properties(fheroes2 PROPERTIES MACOSX_BUNDLE_BUNDLE_VERSION ${CMAKE_PROJECT_VERSION})
@@ -54,12 +100,11 @@ else(MACOS_APP_BUNDLE)
 		OUTPUT_VARIABLE FHEROES2_DATA_ABSOLUTE
 		)
 
-	add_executable(
-		fheroes2
-		${FHEROES2_SOURCES}
-		${CMAKE_CURRENT_SOURCE_DIR}/../resources/fheroes2.manifest
-		${CMAKE_CURRENT_SOURCE_DIR}/../resources/fheroes2.rc
-		)
+        add_executable(
+                fheroes2
+                ${CMAKE_CURRENT_SOURCE_DIR}/../resources/fheroes2.manifest
+                ${CMAKE_CURRENT_SOURCE_DIR}/../resources/fheroes2.rc
+                )
 
 	target_compile_definitions(
 		fheroes2
@@ -107,8 +152,9 @@ target_include_directories(
 	world
 	)
 
-target_link_libraries(
-	fheroes2
-	engine
-	${USE_SDL_VERSION}::${USE_SDL_VERSION}main
-	)
+        target_link_libraries(
+                fheroes2
+                fheroes2core
+                engine
+                ${USE_SDL_VERSION}::${USE_SDL_VERSION}main
+                )

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -19,6 +19,7 @@
 ###########################################################################
 
 add_library(smacker STATIC libsmacker/smacker.c)
+set_target_properties(smacker PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(
 	smacker


### PR DESCRIPTION
## Summary
- add `python` directory with simple pybind using Python C API
- expose `get_version` and `run_game` bindings
- build Python module with CMake and link to new `fheroes2core` library
- refactor `src/fheroes2` build so sources are in `fheroes2core` library
- include python bindings in top-level CMake

## Testing
- `bash script/tools/check_code_format.sh`
- `cmake ..` *(configured)*
- `cmake --build . -j2` *(interrupted due to long compile)*

------
https://chatgpt.com/codex/tasks/task_e_683d92c519b88320a4b3a756efd12525