### PR TITLE
Enable Python bindings and add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ To assist with the graphical asset efforts of the project, please look at our [*
 
 If you would like to help translating the project, please read the [**translation guide**](docs/TRANSLATION.md).
 
+### Python bindings
+
+You can build a Python extension module exposing the game engine. Configure the
+project with CMake as usual and the `fheroes2` module will be created inside the
+`build` directory. It allows running the game directly from Python and querying
+basic information such as the engine version.
+
+Example usage:
+
+```python
+import fheroes2
+
+print("Engine version:", fheroes2.get_version())
+
+# Start the game. Arguments match the command line interface.
+fheroes2.run_game()
+```
+
 ### Developing fheroes2 documentation site
 
 To build the [website](https://ihhub.github.io/fheroes2/) from source, please follow

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,26 @@
+# Python bindings for fheroes2
+
+This directory contains a minimal Python extension module exposing the `fheroes2` engine.
+
+## Building
+
+Use CMake to configure and build the project. The module is produced alongside the C++ binaries:
+
+```bash
+cmake -B build
+cmake --build build
+```
+
+After compilation the shared library `fheroes2$(python3-config --extension-suffix)` will be located in the `build/python` directory.
+You can either copy this file next to your scripts or adjust `PYTHONPATH`.
+
+## Example usage
+
+````python
+import fheroes2
+
+print("Version:", fheroes2.get_version())
+
+# Run the game with default arguments
+fheroes2.run_game()
+````

--- a/python/example.py
+++ b/python/example.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Minimal example showing how to launch fheroes2 from Python."""
+
+import fheroes2
+
+print("fheroes2 version:", fheroes2.get_version())
+
+# Start the game with no command line arguments.
+# You can pass parameters as you would on the command line,
+# for example: fheroes2.run_game("--map", "test.mp2")
+fheroes2.run_game()

--- a/python/pyfheroes2.cpp
+++ b/python/pyfheroes2.cpp
@@ -1,8 +1,10 @@
 #include <Python.h>
-#include "fheroes2/system/settings.h"
+#include "settings.h"
 #include <SDL_main.h>
 #include <vector>
 #include <string>
+
+extern "C" int main( int argc, char ** argv );
 
 static PyObject * py_get_version( PyObject *, PyObject * )
 {
@@ -32,7 +34,7 @@ static PyObject * py_run_game( PyObject *, PyObject * args )
     }
     argv.push_back( nullptr );
 
-    int result = SDL_main( static_cast<int>( argv.size() - 1 ), argv.data() );
+    int result = main( static_cast<int>( argv.size() - 1 ), argv.data() );
     return PyLong_FromLong( result );
 }
 

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -25,6 +25,7 @@ add_compile_options("$<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang,GNU>:${GNU_CXX
 add_compile_options("$<$<OR:$<COMPILE_LANG_AND_ID:C,MSVC>,$<COMPILE_LANG_AND_ID:CXX,MSVC>>:${MSVC_CC_WARN_OPTS}>")
 
 add_library(engine STATIC ${LIBENGINE_SOURCES})
+set_target_properties(engine PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_compile_definitions(
 	engine

--- a/src/thirdparty/CMakeLists.txt
+++ b/src/thirdparty/CMakeLists.txt
@@ -19,6 +19,7 @@
 ###########################################################################
 
 add_library(smacker STATIC libsmacker/smacker.c)
+set_target_properties(smacker PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(
 	smacker


### PR DESCRIPTION
## Summary
- enable building static libraries with PIC for Python module
- expose `main` to Python and fix include paths
- document Python bindings in README and provide a simple example script

## Testing
- `cmake --build . -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_683d98373a608320a8e387ce119a7fdc