### PR TITLE
Automate venv creation in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,12 +74,20 @@ add_subdirectory(src)
 # Translation files
 #
 find_package(Python3 COMPONENTS Interpreter)
+if(Python3_Interpreter_FOUND)
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/script/setup_python_venv.py --print-python
+        OUTPUT_VARIABLE VENV_PYTHON
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
+endif()
 find_program(MAKE_EXECUTABLE NAMES make gmake mingw32-make)
 if(Python3_Interpreter_FOUND)
         add_custom_target(
                 translations
                 ALL
-                COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/files/lang/compile_translations.py
+                COMMAND ${VENV_PYTHON} ${CMAKE_SOURCE_DIR}/files/lang/compile_translations.py
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/files/lang
                 )
 elseif(MAKE_EXECUTABLE)

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,11 @@ PROJECT_VERSION := $(file < version.txt)
 .PHONY: all clean
 
 PYTHON ?= python3
+VENV_PYTHON := $(shell $(PYTHON) script/setup_python_venv.py --print-python)
 
 all:
 $(MAKE) -C src/dist
-$(PYTHON) files/lang/compile_translations.py
+$(VENV_PYTHON) files/lang/compile_translations.py
 ifdef FHEROES2_MACOS_APP_BUNDLE
 	mkdir -p fheroes2.app/Contents/MacOS
 	mkdir -p fheroes2.app/Contents/Resources/h2d
@@ -63,5 +64,5 @@ endif
 
 clean:
 $(MAKE) -C src/dist clean
-$(PYTHON) files/lang/compile_translations.py clean
+$(VENV_PYTHON) files/lang/compile_translations.py clean
 -rm -rf fheroes2 fheroes2.app

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To build the [website](https://ihhub.github.io/fheroes2/) from source, please fo
 
 ### Python Tools
 
-The repository contains helper scripts in `script/tools`. See [docs/PYTHON_SUPPORT.md](docs/PYTHON_SUPPORT.md) for instructions on setting up a Python environment.
+The repository contains helper scripts in `script/tools`. Python 3.8 or newer must be installed. The build will automatically create a `venv` directory and install the required packages. See [docs/PYTHON_SUPPORT.md](docs/PYTHON_SUPPORT.md) for details.
 
 ## Donation
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -53,24 +53,11 @@ If you would like to build the project using CMake please follow the instruction
 
 ### Python helper tools
 
-The repository includes several helper scripts written in Python. To use them you need a working Python 3.8 or newer installation.
+The repository includes several helper scripts written in Python. A working Python 3.8 or newer installation **must** be available on your system.
 
-* Create a virtual environment in the project directory:
+When running `make` or configuring the project with CMake the build system automatically creates a `venv` directory and installs the dependencies from `requirements.txt` if the environment does not already exist. All Python scripts are executed using this environment.
 
-  ```bash
-  python -m venv venv
-  ```
-
-* Activate the environment and install the required packages:
-
-  ```bash
-  source venv/bin/activate  # Linux/macOS
-  venv\Scripts\activate    # Windows
-  pip install -r requirements.txt
-  ```
-
-If package installation fails or Python cannot be found, ensure that Python and `pip` are available in your system path.
-Rerun the commands and see [PYTHON_SUPPORT.md](PYTHON_SUPPORT.md) for additional guidance.
+If Python is missing entirely the build will fail. See [PYTHON_SUPPORT.md](PYTHON_SUPPORT.md) for additional guidance.
 
 ## Building the front end website
 

--- a/docs/PYTHON_SUPPORT.md
+++ b/docs/PYTHON_SUPPORT.md
@@ -9,6 +9,8 @@ This project includes helper tools written in Python. If you want to extend thes
 
 ## Setting up a virtual environment
 
+When running the build system a `venv` directory will be created automatically if it does not exist and the required packages from `requirements.txt` will be installed. You only need to perform the following steps manually if you want to work with the Python tools outside of the build process.
+
 1. Create a virtual environment in the project directory:
 
    ```bash

--- a/docs/README_cmake.md
+++ b/docs/README_cmake.md
@@ -37,7 +37,7 @@ Your vcpkg is ready to install external libraries. Assuming that you use x64 sys
 ```shell
 .\vcpkg\vcpkg --triplet x64-windows install sdl2 sdl2-image sdl2-mixer zlib gettext 
 ```
-Python 3 is also required for compiling translation files. The build will automatically run `files/lang/compile_translations.py` when a Python interpreter is available.
+Python 3 is also required for compiling translation files. The build system automatically creates a `venv` directory and installs the dependencies from `requirements.txt` if needed, then runs `files/lang/compile_translations.py` using that environment.
 
 If you planning to develop fheroes2 with Visual Studio, you may want to integrate vcpkg with it (requires elevated admin privileges).
 After following command Visual Studio automagically will find all required dependencies:

--- a/script/setup_python_venv.py
+++ b/script/setup_python_venv.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+
+def get_python_path(venv_dir: Path) -> Path:
+    if os.name == 'nt':
+        return venv_dir / 'Scripts' / 'python.exe'
+    return venv_dir / 'bin' / 'python'
+
+
+def ensure_venv(root: Path) -> Path:
+    venv_dir = root / 'venv'
+    py_path = get_python_path(venv_dir)
+    if not py_path.exists():
+        print(f"Creating virtual environment in {venv_dir}")
+        subprocess.check_call([sys.executable, '-m', 'venv', str(venv_dir)])
+        subprocess.check_call([str(get_python_path(venv_dir)), '-m', 'pip', 'install', '-r', str(root / 'requirements.txt')])
+    return py_path
+
+
+def main():
+    root = Path(__file__).resolve().parent.parent
+    py_path = ensure_venv(root)
+    if '--print-python' in sys.argv:
+        print(py_path)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as exc:
+        sys.stderr.write(f"Error: {exc}\n")
+        sys.exit(1)
+


### PR DESCRIPTION
## Summary
- create helper script `setup_python_venv.py` that sets up a virtual environment
- update `Makefile` and `CMakeLists.txt` to use the venv
- document automatic venv creation and Python requirement

## Testing
- `python3 script/setup_python_venv.py --print-python` *(fails: could not install packages)*
- `make --version`

------
https://chatgpt.com/codex/tasks/task_e_683db026350083209af96e14cae32c76