### PR TITLE
Add automatic venv cleanup

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -55,7 +55,7 @@ If you would like to build the project using CMake please follow the instruction
 
 The repository includes several helper scripts written in Python. A working Python 3.8 or newer installation **must** be available on your system.
 
-When running `make` or configuring the project with CMake the build system automatically creates a `venv` directory and installs the dependencies from `requirements.txt` if the environment does not already exist. All Python scripts are executed using this environment.
+When running `make` or configuring the project with CMake the build system automatically creates a `venv` directory and installs the dependencies from `requirements.txt` if the environment does not already exist. If a leftover `venv` directory is detected but no valid interpreter is found, it will be removed automatically before a fresh environment is created. All Python scripts are executed using this environment.
 
 If Python is missing entirely the build will fail. See [PYTHON_SUPPORT.md](PYTHON_SUPPORT.md) for additional guidance.
 

--- a/docs/PYTHON_SUPPORT.md
+++ b/docs/PYTHON_SUPPORT.md
@@ -9,7 +9,7 @@ This project includes helper tools written in Python. If you want to extend thes
 
 ## Setting up a virtual environment
 
-When running the build system a `venv` directory will be created automatically if it does not exist and the required packages from `requirements.txt` will be installed. You only need to perform the following steps manually if you want to work with the Python tools outside of the build process.
+When running the build system a `venv` directory will be created automatically if it does not exist and the required packages from `requirements.txt` will be installed. Any stale `venv` directory without a proper interpreter is removed automatically before a new environment is created. You only need to perform the following steps manually if you want to work with the Python tools outside of the build process.
 
 1. Create a virtual environment in the project directory:
 

--- a/script/tools/python/setup_python_venv.py
+++ b/script/tools/python/setup_python_venv.py
@@ -2,6 +2,7 @@
 import os
 import sys
 import subprocess
+import shutil
 from pathlib import Path
 
 
@@ -15,6 +16,8 @@ def ensure_venv(root: Path) -> Path:
     venv_dir = root / "venv"
     py_path = get_python_path(venv_dir)
     if not py_path.exists():
+        if venv_dir.exists():
+            shutil.rmtree(venv_dir)
         print(f"Creating virtual environment in {venv_dir}")
         subprocess.check_call([sys.executable, "-m", "venv", str(venv_dir)])
         subprocess.check_call(


### PR DESCRIPTION
## Summary
- automatically remove a stale `venv` when setting up the Python environment
- document the cleanup behavior in development guides

## Testing
- `python3 script/tools/python/setup_python_venv.py --print-python` *(fails: cannot reach pip index)*

------
https://chatgpt.com/codex/tasks/task_e_683db9aaff9083209209dba1db6ca460